### PR TITLE
[programs] Add C/C++ programs from nanvix/nanvix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ NANVIX_REPO ?= nanvix/nanvix
 NANVIX_DIR ?= .nanvix
 
 # Test suites to build.
-SUITES := c-bindings dlfcn-c dlfcn-pie-c file-c memory-c misc-c network-c thread-c
+SUITES := c-bindings dlfcn-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 # ELF binaries produced by each suite.
 BINARIES := $(addsuffix .elf,$(SUITES))

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
-# POSIX C Test Suites for Nanvix
+# POSIX C/C++ Test Suites for Nanvix
 
-A collection of C test suites that validate the POSIX compatibility layer of
-[Nanvix](https://github.com/nanvix/nanvix). These tests exercise file system operations,
-threading, memory management, networking, dynamic linking, and other POSIX interfaces.
+A collection of C and C++ test suites and programs that validate the POSIX compatibility layer of
+[Nanvix](https://github.com/nanvix/nanvix). These cover file system operations,
+threading, memory management, networking, dynamic linking, and other POSIX interfaces,
+as well as simple echo, hello-world, and no-op benchmarks.
 
 ## Test Suites
 
 | Suite | Description |
 |---|---|
+| `c-bindings` | Rust-C FFI type size/alignment validation |
+| `dlfcn-c` | Dynamic linking (dlopen, dlsym) |
+| `dlfcn-pie-c` | PIE dynamic linking |
+| `echo-c` | Echo stdin to stdout (C) |
+| `echo-cpp` | Echo stdin to stdout (C++) |
 | `file-c` | File system operations (open, read, write, stat, link, mkdir, etc.) |
-| `thread-c` | Threading, mutexes, condition variables, rwlocks, TLS, TDA |
+| `hello-c` | Hello world (C) |
+| `hello-cpp` | Hello world (C++) |
 | `memory-c` | malloc/free, aligned\_alloc, realloc, mmap/munmap, heap stress |
 | `misc-c` | UID/GID, clock/time, uname, hostname, nanosleep, getenv |
 | `network-c` | IPv4 (INET) and Unix domain sockets |
-| `dlfcn-c` | Dynamic linking (dlopen, dlsym) |
-| `dlfcn-pie-c` | PIE dynamic linking |
-| `c-bindings` | Rust-C FFI type size/alignment validation |
+| `noop-c` | No-op program (C) |
+| `noop-cpp` | No-op program (C++) |
+| `thread-c` | Threading, mutexes, condition variables, rwlocks, TLS, TDA |
 
 ## Prerequisites
 
@@ -46,14 +53,20 @@ make run SUITE=file-c
 ├── Dockerfile         # Cross-compilation inside the Nanvix Docker image
 └── src/
     ├── Makefile       # Container-side orchestrator
+    ├── c-bindings/    # Rust-C FFI validation
+    ├── dlfcn-c/       # Dynamic linking test suite
+    ├── dlfcn-pie-c/   # PIE dynamic linking test suite
+    ├── echo-c/        # Echo program (C)
+    ├── echo-cpp/      # Echo program (C++)
     ├── file-c/        # File system test suite
-    ├── thread-c/      # Threading test suite
+    ├── hello-c/       # Hello world (C)
+    ├── hello-cpp/     # Hello world (C++)
     ├── memory-c/      # Memory management test suite
     ├── misc-c/        # Miscellaneous POSIX test suite
     ├── network-c/     # Networking test suite
-    ├── dlfcn-c/       # Dynamic linking test suite
-    ├── dlfcn-pie-c/   # PIE dynamic linking test suite
-    └── c-bindings/    # Rust-C FFI validation
+    ├── noop-c/        # No-op program (C)
+    ├── noop-cpp/      # No-op program (C++)
+    └── thread-c/      # Threading test suite
 ```
 
 ## How It Works
@@ -67,6 +80,7 @@ Each test suite is linked against:
 
 - **`libposix.a`** — Nanvix POSIX compatibility layer (from the Nanvix release)
 - **`libc.a`** — Newlib C library (from the toolchain)
+- **`libstdc++.a`** — C++ standard library (from the toolchain, for C++ suites)
 - **`user.ld`** — Linker script defining the Nanvix user-space memory layout (from the Nanvix release)
 
 ### Running

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ MEMORY_SIZE ?= 128mb
 
 # Cross-compiler.
 export CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
+export CXX := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-g++
 
 # Compiler flags.
 export CFLAGS := -std=c17
@@ -31,6 +32,18 @@ ifeq ($(PROCESS_MODE),standalone)
 CFLAGS += -D__NANVIX_STANDALONE__
 endif
 
+# C++ compiler flags.
+export CXXFLAGS := -std=c++17
+CXXFLAGS += -m32 -march=pentiumpro -Wa,-march=pentiumpro
+CXXFLAGS += -Wall -Wextra -Werror
+CXXFLAGS += -O2
+CXXFLAGS += -D__NANVIX_SYSNAME__=\"nanvix\"
+CXXFLAGS += -D__NANVIX_NODENAME__=\"localhost\"
+CXXFLAGS += -D__$(PLATFORM)__
+ifeq ($(PROCESS_MODE),standalone)
+CXXFLAGS += -D__NANVIX_STANDALONE__
+endif
+
 # Linker flags.
 export LDFLAGS := -z noexecstack -T $(NANVIX_SYSROOT)/lib/user.ld
 
@@ -38,6 +51,8 @@ export LDFLAGS := -z noexecstack -T $(NANVIX_SYSROOT)/lib/user.ld
 export LIBPOSIX := $(NANVIX_SYSROOT)/lib/libposix.a
 export LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
 export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
+export LIBCXX := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libstdc++.a
+export LIBRARIES_CXX := -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-group
 
 # Output directory for compiled binaries.
 export BINARIES_DIR ?= $(CURDIR)/../build
@@ -49,7 +64,7 @@ export LIBRARIES_DIR ?= $(BINARIES_DIR)
 # Test Suites
 #===============================================================================
 
-SUITES := c-bindings dlfcn-c dlfcn-pie-c file-c memory-c misc-c network-c thread-c
+SUITES := c-bindings dlfcn-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 #===============================================================================
 # Build Rules
@@ -79,7 +94,7 @@ $(BINARIES_DIR):
 # file-c needs VFS access (tests open/read/write on files).
 # network-c needs network infrastructure (sockets).
 # misc-c needs environment variable setup (NANVIX_TEST).
-TESTABLE_SUITES := c-bindings memory-c thread-c
+TESTABLE_SUITES := c-bindings echo-c echo-cpp hello-c hello-cpp memory-c noop-c noop-cpp thread-c
 
 test: test-smoke test-integration
 

--- a/src/echo-c/Makefile
+++ b/src/echo-c/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := echo-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/echo-c/main.c
+++ b/src/echo-c/main.c
@@ -1,0 +1,43 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#include <stddef.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+#define MAX_REQUEST_SIZE 4096
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+char buffer[MAX_REQUEST_SIZE];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+int main(void)
+{
+    ssize_t nread = 0;
+
+    while (1) {
+        nread = read(STDIN_FILENO, buffer, MAX_REQUEST_SIZE);
+        if (nread < 0) {
+            break; // Error encountered.
+        } else if (nread == 0) {
+            break; // End of file reached.
+        }
+
+        if (nread > 0) {
+            write(STDOUT_FILENO, buffer, nread);
+        }
+    }
+
+    return 0;
+}

--- a/src/echo-cpp/Makefile
+++ b/src/echo-cpp/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := echo-cpp
+
+SOURCES := $(wildcard *.cpp)
+OBJECTS := $(SOURCES:.cpp=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES_CXX) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/src/echo-cpp/main.cpp
+++ b/src/echo-cpp/main.cpp
@@ -1,0 +1,42 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+constexpr size_t MAX_REQUEST_SIZE = 4096;
+
+//==================================================================================================
+// Global Variables
+//==================================================================================================
+
+static char buffer[MAX_REQUEST_SIZE];
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+int main()
+{
+    ssize_t nread = 0;
+
+    while (true) {
+        nread = read(STDIN_FILENO, buffer, MAX_REQUEST_SIZE);
+        if (nread < 0) {
+            break; // Error encountered.
+        } else if (nread == 0) {
+            break; // End of file reached.
+        }
+
+        if (nread > 0) {
+            write(STDOUT_FILENO, buffer, nread);
+        }
+    }
+
+    return 0;
+}

--- a/src/hello-c/Makefile
+++ b/src/hello-c/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := hello-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/hello-c/main.c
+++ b/src/hello-c/main.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright(c) 2011-2024 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <stdio.h>
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Hello, world from C!\n");
+
+    return (0);
+}

--- a/src/hello-cpp/Makefile
+++ b/src/hello-cpp/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := hello-cpp
+
+SOURCES := $(wildcard *.cpp)
+OBJECTS := $(SOURCES:.cpp=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES_CXX) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/src/hello-cpp/main.cpp
+++ b/src/hello-cpp/main.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright(c) 2011-2024 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello, world from C++!" << std::endl;
+
+    return 0;
+}

--- a/src/noop-c/Makefile
+++ b/src/noop-c/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := noop-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CC) $(LDFLAGS) $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c -o $@

--- a/src/noop-c/main.c
+++ b/src/noop-c/main.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright(c) 2011-2024 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    return (0);
+}

--- a/src/noop-cpp/Makefile
+++ b/src/noop-cpp/Makefile
@@ -1,0 +1,18 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+PROGRAM_NAME := noop-cpp
+
+SOURCES := $(wildcard *.cpp)
+OBJECTS := $(SOURCES:.cpp=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS)
+	$(CXX) $(LDFLAGS) $(OBJECTS) $(LIBRARIES_CXX) -o $(BINARIES_DIR)/$(BINARY)
+
+clean:
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/src/noop-cpp/main.cpp
+++ b/src/noop-cpp/main.cpp
@@ -1,0 +1,9 @@
+/*
+ * Copyright(c) 2011-2024 The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Move echo-c, echo-cpp, hello-c, hello-cpp, noop-c, and noop-cpp programs from the nanvix/nanvix repository to the posix-tests repository.

## Changes
- Add echo-c, echo-cpp, noop-c, noop-cpp (benchmarks from `src/benchmarks/`)
- Add hello-c, hello-cpp (user applications from `src/user/`)
- Add C++ toolchain support (`CXX`, `CXXFLAGS`, `LIBRARIES_CXX`) to `src/Makefile`
- Update `SUITES` list in both Makefiles
- Add new suites to `TESTABLE_SUITES`
- Update README with new suites and C++ library reference

## Context
These programs are being removed from the main nanvix/nanvix repository as part of the effort to eliminate the GCC build dependency from the main build (PR https://github.com/nanvix/nanvix/pull/1786).