### PR TITLE
fix: upgrade nanvix-zutil v0.2.2 → v0.7.19

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -9,9 +9,11 @@ on:
   push:
     branches:
       - main
+      - "nanvix/**"
   pull_request:
     branches:
       - main
+      - "nanvix/**"
   workflow_dispatch:
   repository_dispatch:
     types: [nanvix-minor-release, nanvix-major-release]
@@ -20,114 +22,18 @@ permissions:
   contents: write
   actions: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
-  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: hyperlight
-            process-mode: multi-process
-            memory: 128mb
-          - platform: hyperlight
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: multi-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: standalone
-            memory: 128mb
-    name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-    container:
-      image: nanvix/toolchain:latest-minimal
-      options: --device /dev/kvm
-    defaults:
-      run:
-        shell: bash
-    env:
-      NANVIX_MACHINE: ${{ matrix.platform }}
-      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
-      NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
-      USER: runner
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          apt-get update -qq && apt-get install -y -qq python3-pip
-          ./z setup
-
-      - name: Build
-        run: ./z build
-
-      - name: Test
-        if: matrix.process-mode != 'standalone'
-        run: ./z test
-
-      - name: Test (standalone — smoke + integration only)
-        if: matrix.process-mode == 'standalone'
-        run: ./z test -- test-smoke test-integration
-
-      - name: Release
-        if: success()
-        run: ./z release
-
-      - name: Upload Build Artifacts
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: posix-tests-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: dist/*.tar.bz2
-          retention-days: 7
-
-      - name: Collect failure logs
-        if: failure()
-        run: |
-          mkdir -p ci-logs
-          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
-          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
-          ls -lah ci-logs || true
-
-      - name: Upload failure logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
-          path: ci-logs/*
-          if-no-files-found: warn
-
-  report-failure:
-    needs: [build]
-    if: >-
-      ${{ always() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build.result == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create failure issue
-        uses: actions/github-script@v7
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `CI failure (run ${context.runNumber})`,
-              body: `The posix-tests CI workflow failed.\n- Trigger: ${context.eventName}\n- Run: [#${context.runNumber}](${runUrl})\n- SHA: ${context.sha}\n- build: ${process.env.BUILD_RESULT}\n\nPlease investigate.`,
-              assignees: ['ppenna']
-            });
+  ci:
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.7.6
+    with:
+      zutil-version: "v0.7.19"
+      caller-event-name: ${{ github.event_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,0 +1,10 @@
+[package]
+name = "posix-tests"
+version = "0.1.0"
+nanvix-version = "0.12.410"
+
+[builds]
+[builds.matrix]
+platforms = ["hyperlight", "microvm"]
+modes = ["multi-process", "single-process", "standalone"]
+memory = ["128mb"]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,7 +11,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
-from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, EXIT_MISSING_DEP, Sysroot, ZScript, log
+from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_SYSROOT = "NANVIX_SYSROOT"
@@ -23,8 +23,6 @@ _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
 class PosixTestsBuild(ZScript):
     """Build script for nanvix/posix-tests."""
-
-    NANVIX_TAG = "latest"
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
@@ -51,20 +49,7 @@ class PosixTestsBuild(ZScript):
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
-        tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
-        if not tag:
-            log.fatal(f"{CFG_TAG} is not set.", code=EXIT_MISSING_DEP)
-
-        sysroot = Sysroot.download(
-            machine=self.config.machine,
-            deployment_mode=self.config.deployment_mode,
-            memory_size=self.config.memory_size,
-            tag=tag,
-            gh_token=self.config.get(CFG_GH_TOKEN),
-        )
-        sysroot.verify(self.sysroot_required_files())
-        self.config.set(CFG_SYSROOT, str(sysroot.path))
-        self.config.save()
+        super().setup()
 
     def build(self) -> None:
         """Cross-compile all POSIX test suites for Nanvix."""

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ init: $(NANVIX_DIR)/lib/libposix.a
 
 $(NANVIX_DIR)/lib/libposix.a:
 	@echo "Downloading the latest Nanvix release..."
-	@RELEASE_INFO=$$(gh release view latest --repo "$(NANVIX_REPO)" --json tagName,assets); \
+	@RELEASE_INFO=$$(gh release view --repo "$(NANVIX_REPO)" --json tagName,assets); \
 	TAG_NAME=$$(echo "$$RELEASE_INFO" | jq -r '.tagName'); \
 	ASSET_NAME=$$(echo "$$RELEASE_INFO" | jq -r \
-		'.assets[] | select(.name | startswith("nanvix-microvm-multi-process-release")) | .name'); \
+		'.assets[] | select(.name | startswith("nanvix-x86-microvm-multi-process-release")) | .name'); \
 	if [ -z "$$ASSET_NAME" ]; then \
 		echo "ERROR: Could not find a microvm multi-process release asset." >&2; \
 		exit 1; \
@@ -73,7 +73,7 @@ $(NANVIX_DIR)/lib/libposix.a:
 	fi; \
 	echo "  Docker image: $$DOCKER_IMAGE"; \
 	TMPDIR=$$(mktemp -d); \
-	gh release download latest --repo "$(NANVIX_REPO)" \
+	gh release download "$$TAG_NAME" --repo "$(NANVIX_REPO)" \
 		--pattern "$$ASSET_NAME" \
 		--dir "$$TMPDIR"; \
 	mkdir -p $(NANVIX_DIR); \
@@ -84,6 +84,8 @@ $(NANVIX_DIR)/lib/libposix.a:
 	echo "Done. Nanvix release extracted to $(NANVIX_DIR)/."
 
 distclean: clean
-	rm -rf $(NANVIX_DIR)
+	rm -rf $(NANVIX_DIR)/sysroot $(NANVIX_DIR)/cache $(NANVIX_DIR)/buildroot
+	rm -rf $(NANVIX_DIR)/venv $(NANVIX_DIR)/env.json $(NANVIX_DIR)/.docker-image
+	rm -rf $(NANVIX_DIR)/lib $(NANVIX_DIR)/bin $(NANVIX_DIR)/include
 
 .PHONY: all run compile clean init distclean

--- a/z
+++ b/z
@@ -1,119 +1,20 @@
 #!/usr/bin/env bash
-# Bootstrap wrapper for Nanvix build scripts.
-# Modeled on https://github.com/rust-lang/rust/blob/main/x
-
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Unified entry point: delegates to z.sh (Linux/macOS) or z.ps1 (Windows).
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
 set -euo pipefail
 
-# Minimum required Python version.
-MIN_PYTHON_MAJOR=3
-MIN_PYTHON_MINOR=12
-
-# Exit codes (mirrors nanvix-zutil convention).
-EXIT_GENERAL_ERROR=1
-EXIT_MISSING_DEP=3
-
-# nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.2"
-ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
-
-# Locate a suitable Python interpreter.
-find_python() {
-    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
-    # then fall back to generic names.
-    local candidates=()
-    local minor
-    for ((minor=20; minor>=MIN_PYTHON_MINOR; minor--)); do
-        candidates+=("python3.${minor}")
-    done
-    candidates+=("python3" "python" "py")
-    for candidate in "${candidates[@]}"; do
-        if command -v "${candidate}" &>/dev/null; then
-            local version
-            if [[ "${candidate}" == "py" ]]; then
-                version=$("${candidate}" -3 -c \
-                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
-                    2>/dev/null) || continue
-            else
-                version=$("${candidate}" -c \
-                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
-                    2>/dev/null) || continue
-            fi
-            local major minor
-            major=$(echo "${version}" | tr -d '\r' | cut -d. -f1)
-            minor=$(echo "${version}" | tr -d '\r' | cut -d. -f2)
-            if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
-               [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
-                echo "${candidate}"
-                return 0
-            fi
-        fi
-    done
-    return "${EXIT_GENERAL_ERROR}"
-}
-
-# Run the discovered Python interpreter (handles 'py -3' on Windows).
-run_python() {
-    if [[ "${PYTHON}" == "py" ]]; then
-        "${PYTHON}" -3 "$@"
-    else
-        "${PYTHON}" "$@"
-    fi
-}
-
-PYTHON=$(find_python) || {
-    echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
-    echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
-    exit "${EXIT_MISSING_DEP}"
-}
-
-# Resolve the directory containing this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
-VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
 
-# Detect venv interpreter path (Scripts/python.exe on Windows/MSYS).
-if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
-    VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
-else
-    VENV_PYTHON="${VENV_DIR}/bin/python"
-fi
-
-if [[ ! -f "${Z_SCRIPT}" ]]; then
-    echo "error: ${Z_SCRIPT} not found." >&2
-    echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
-    exit "${EXIT_MISSING_DEP}"
-fi
-
-# Bootstrap: create venv and install nanvix-zutil if needed.
-if [[ ! -f "${VENV_PYTHON}" ]]; then
-    echo "bootstrap: creating venv …" >&2
-    run_python -m venv "${VENV_DIR}"
-
-    # Re-detect after venv creation.
-    if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
-        VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
-    fi
-
-    if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
-        echo "bootstrap: installing nanvix-zutil (editable) …" >&2
-        "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
-    else
-        version="${ZUTIL_TAG#v}"
-        version="${version//-/}"
-        whl_name="nanvix_zutil-${version}-py3-none-any.whl"
-        whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
-        echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
-        tmp_req=$(mktemp)
-        trap 'rm -f "${tmp_req}"' EXIT
-        echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
-        "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
-        rm -f "${tmp_req}"
-        trap - EXIT
-    fi
-fi
-
-exec "${VENV_PYTHON}" "${Z_SCRIPT}" "$@"
+case "$(uname -s)" in
+    CYGWIN* | MINGW* | MSYS*)
+        exec powershell.exe -NoProfile -ExecutionPolicy Bypass \
+            -File "$SCRIPT_DIR/z.ps1" "$@"
+        ;;
+    *)
+        exec "$SCRIPT_DIR/z.sh" "$@"
+        ;;
+esac

--- a/z.ps1
+++ b/z.ps1
@@ -1,0 +1,125 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Self-bootstraps nanvix-zutil into .nanvix\venv\ if it is not already installed.
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ZArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
+    $env:NANVIX_ZUTIL_VERSION
+}
+else {
+    "0.7.19"
+}
+$zutilVersion = $zutilVersion -replace "^v", ""
+
+# z.ps1 lives at the repository root, so use its directory directly
+# instead of relying on git to discover the top-level checkout directory.
+$repoRoot = $PSScriptRoot
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+# Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
+# which are unavailable on Windows.  Stub them before importing the package.
+$ShimCode = @'
+import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+'@
+
+$zutilGlobalVersion = try {
+    & nanvix-zutil --version 2>$null
+}
+catch {
+    $null
+}
+
+function Bootstrap {
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Information "nanvix-zutil not found -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+
+    # Discover a Python 3 interpreter.
+    $venvArgs = @("-m", "venv")
+    if (Test-Path $venvDir) {
+        $venvArgs += "--clear"
+    }
+    $venvArgs += $venvDir
+
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 @venvArgs
+    }
+    elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python @venvArgs
+    }
+    elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 @venvArgs
+    }
+    else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "venv creation failed (exit code $LASTEXITCODE)"
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install failed (exit code $LASTEXITCODE)"
+    }
+}
+
+# Prefer the venv copy if it exists; otherwise use the global install.
+$bin = $null
+if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+    Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+elseif (Test-Path $venvZutil) {
+    # Use the shim to check version -- running the exe directly fails on
+    # Windows because os.getuid/os.getgid are unavailable (see FIXME above).
+    $venvVersion = try {
+        & $venvPython -c $ShimCode --version 2>$null
+    }
+    catch {
+        $null
+    }
+    if ($venvVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "Venv nanvix-zutil version mismatch. Expected ${zutilVersion}, found ${venvVersion}. Re-bootstrapping..."
+        Bootstrap
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+    }
+    $bin = $venvZutil
+}
+elseif ((Test-Path $venvDir) -and (-not $zutilGlobalVersion)) {
+    Write-Warning "Incomplete venv detected (binary missing). Re-running bootstrap..."
+    Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+else {
+    $bin = "nanvix-zutil"
+    if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+    }
+}
+
+if ($bin -eq $venvZutil) {
+    & $venvPython -c $ShimCode @ZArgs
+}
+else {
+    & $bin @ZArgs
+}
+exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Self-bootstraps nanvix-zutil into .nanvix/venv/ if it is not already installed.
+
+set -euo pipefail
+
+PINNED_VERSION="0.7.19"
+RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
+ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
+ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
+
+function bootstrap() {
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    echo "nanvix-zutil not found -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
+
+    WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
+}
+
+# Prefer the venv copy if it exists; otherwise use the global install.
+BIN=""
+if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+    bootstrap
+    BIN="$VENV_BIN"
+elif [ -x "$VENV_BIN" ]; then
+    VENV_VERSION="$("$VENV_BIN" --version 2>/dev/null || true)"
+    if [ "$VENV_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: venv nanvix-zutil version mismatch. Expected ${ZUTIL_VERSION}, found ${VENV_VERSION}. Re-bootstrapping..." >&2
+        bootstrap
+    fi
+    BIN="$VENV_BIN"
+elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
+    echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
+    bootstrap
+    BIN="$VENV_BIN"
+else
+    BIN="nanvix-zutil"
+    if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+    fi
+fi
+
+exec "$BIN" "$@"


### PR DESCRIPTION
## Summary

Upgrades nanvix-zutil from v0.2.2 to v0.7.19 to fix the CI failures reported in #13.

## Root Cause

nanvix v0.12.410 (published Apr 14) changed release asset naming from `nanvix-{machine}-...` to `nanvix-x86-{machine}-...`. The old nanvix-zutil v0.2.2 used the previous naming pattern and could no longer find release tarballs.

## Changes

- **Bootstrap**: Replace old `z` Python-finder with the new template structure (`z` dispatcher + `z.sh` + `z.ps1`)
- **Manifest**: Add `.nanvix/nanvix.toml` pinning nanvix to v0.12.410 with the build matrix
- **Build script**: Update `.nanvix/z.py` to use new API (remove deprecated `CFG_TAG`, delegate `setup()` to base class)
- **Makefile**: Fix `init` target for new `nanvix-x86-` asset naming and resolved tag
- **CI workflow**: Replace inline 134-line workflow with thin caller using `nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.7.6`

## Related

- nanvix/workflows#44 (merged) — Added posix-tests to consumer-repos.json for automated zutil updates

Closes #13