### PR TITLE
[ci] E: Update nanvix workflow refs to v1.8.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.7.6
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.8.0
     with:
       zutil-version: "v0.7.21"
       caller-event-name: ${{ github.event_name }}


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.8.0`](https://github.com/nanvix/workflows/releases/tag/v1.8.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.