### PR TITLE
[ci] E: Pin nanvix to v0.12.429

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posix-tests"
 version = "0.1.0"
-nanvix-version = "0.12.420"
+nanvix-version = "0.12.429"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.12.429`](https://github.com/nanvix/nanvix/releases/tag/v0.12.429).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.