### PR TITLE
[dlfcn] E: Add tests for DT_NEEDED and RTLD_GLOBAL symbol resolution

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,7 @@ export LIBRARIES_DIR ?= $(BINARIES_DIR)
 # Test Suites
 #===============================================================================
 
-SUITES := c-bindings dlfcn-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
+SUITES := c-bindings dlfcn-c dlfcn-global-c dlfcn-needed-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 #===============================================================================
 # Build Rules

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,7 +65,7 @@ export LIBRARIES_DIR ?= $(BINARIES_DIR)
 # Test Suites
 #===============================================================================
 
-SUITES := c-bindings dlfcn-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
+SUITES := c-bindings dlfcn-c dlfcn-global-c dlfcn-needed-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 #===============================================================================
 # Build Rules

--- a/src/dlfcn-global-c/Makefile
+++ b/src/dlfcn-global-c/Makefile
@@ -1,0 +1,34 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# dlfcn-global-c: Test RTLD_GLOBAL cross-.so symbol resolution.
+#
+# libconsumer.so is NOT linked against libprovider.so (no DT_NEEDED).
+# The test loads libprovider.so with RTLD_GLOBAL first, then loads
+# libconsumer.so.  Per POSIX, provider symbols should be available
+# to the consumer via the global scope.
+
+PROGRAM_NAME := dlfcn-global-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS) libs-all
+	$(CC) $(LDFLAGS) -pie -rdynamic -Wl,--no-dynamic-linker $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean: libs-clean
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+# libconsumer.so is NOT linked with -lprovider (no DT_NEEDED).
+libs-all:
+	$(CC) libs/provider.c -shared -fPIC -o $(LIBRARIES_DIR)/libprovider.so
+	$(CC) libs/consumer.c -shared -fPIC -o $(LIBRARIES_DIR)/libconsumer.so
+
+libs-clean:
+	rm -f $(LIBRARIES_DIR)/libprovider.so
+	rm -f $(LIBRARIES_DIR)/libconsumer.so
+
+%.o: %.c
+	$(CC) $(CFLAGS) -fPIE $< -c -o $@

--- a/src/dlfcn-global-c/libs/consumer.c
+++ b/src/dlfcn-global-c/libs/consumer.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libconsumer.so - Shared library that depends on libprovider.so
+ *                  WITHOUT a DT_NEEDED entry.
+ *
+ * This library calls provider_add(), provider_mul(), provider_isqrt()
+ * but is NOT linked against libprovider.so at build time.  The symbols
+ * must be resolved at dlopen time from the global scope (RTLD_GLOBAL).
+ *
+ * This pattern occurs in plugin architectures where a host loads a
+ * provider library with RTLD_GLOBAL before loading plugin modules.
+ */
+
+extern int provider_add(int a, int b);
+extern int provider_mul(int a, int b);
+extern int provider_isqrt(int x);
+
+int consumer_add(int a, int b)
+{
+    return provider_add(a, b);
+}
+
+int consumer_mul(int a, int b)
+{
+    return provider_mul(a, b);
+}
+
+int consumer_isqrt(int x)
+{
+    return provider_isqrt(x);
+}
+
+/* Function with no cross-library dependency (control case). */
+int consumer_noop(int x)
+{
+    return x + 1;
+}

--- a/src/dlfcn-global-c/libs/provider.c
+++ b/src/dlfcn-global-c/libs/provider.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libprovider.so - Self-contained shared library that exports functions.
+ *
+ * All functions are implemented inline with no external dependencies,
+ * so this library has ZERO undefined symbols and always loads successfully.
+ */
+
+int provider_add(int a, int b)
+{
+    return a + b;
+}
+
+int provider_mul(int a, int b)
+{
+    return a * b;
+}
+
+/* Integer square root via Newton's method. */
+int provider_isqrt(int x)
+{
+    if (x <= 0)
+        return 0;
+    int r = x;
+    while (r > x / r)
+        r = (r + x / r) / 2;
+    return r;
+}

--- a/src/dlfcn-global-c/main.c
+++ b/src/dlfcn-global-c/main.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-global-c: Test RTLD_GLOBAL cross-.so symbol resolution.
+ *
+ * This tests the plugin pattern where a host pre-loads a provider
+ * library with RTLD_GLOBAL, then loads consumer plugins that reference
+ * the provider's symbols without DT_NEEDED linkage.
+ *
+ * Per POSIX, RTLD_GLOBAL should make a library's symbols available
+ * for symbol resolution of subsequently loaded libraries.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 1: Load libconsumer.so WITHOUT loading libprovider.so first.
+ * Expected: FAIL — provider_add/mul/isqrt are unresolved.
+ */
+static void test_consumer_alone_fails(void)
+{
+    void *h = dlopen("lib/libconsumer.so", RTLD_NOW);
+    if (h == NULL) {
+        pass("consumer alone fails");
+        return;
+    }
+
+    fail("consumer alone fails",
+         "dlopen should have returned NULL for unresolved symbols");
+    dlclose(h);
+}
+
+/*
+ * Test 2: Load libprovider.so with RTLD_GLOBAL, then libconsumer.so.
+ *
+ * Per POSIX, RTLD_GLOBAL should make libprovider.so's exports
+ * available to subsequently loaded libraries.
+ */
+static void test_global_provides_symbols(void)
+{
+    printf("  [2a] loading provider with RTLD_GLOBAL...\n");
+    fflush(stdout);
+
+    void *prov = dlopen("lib/libprovider.so", RTLD_GLOBAL);
+    if (prov == NULL) {
+        fail("RTLD_GLOBAL cross-lib", dlerror());
+        return;
+    }
+    printf("  [2b] provider loaded, loading consumer...\n");
+    fflush(stdout);
+
+    void *cons = dlopen("lib/libconsumer.so", RTLD_NOW);
+    printf("  [2c] consumer dlopen returned %p\n", (void *)cons);
+    fflush(stdout);
+
+    if (cons == NULL) {
+        fail("RTLD_GLOBAL cross-lib", dlerror());
+        dlclose(prov);
+        return;
+    }
+
+    int (*cadd)(int, int) = NULL;
+    *(void **)(&cadd) = dlsym(cons, "consumer_add");
+    if (cadd == NULL || cadd(10, 20) != 30) {
+        fail("RTLD_GLOBAL cross-lib", "consumer_add() failed");
+        dlclose(cons);
+        dlclose(prov);
+        return;
+    }
+
+    dlclose(cons);
+    dlclose(prov);
+    pass("RTLD_GLOBAL cross-lib");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn RTLD_GLOBAL tests ===\n");
+    fflush(stdout);
+
+    test_consumer_alone_fails();
+    test_global_provides_symbols();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 3);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/src/dlfcn-needed-c/Makefile
+++ b/src/dlfcn-needed-c/Makefile
@@ -1,0 +1,34 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# dlfcn-needed-c: Test DT_NEEDED automatic dependency loading.
+#
+# libconsumer.so is linked against libprovider.so, creating a DT_NEEDED
+# entry.  The loader should auto-load libprovider.so when opening
+# libconsumer.so.  This is the standard mechanism for shared library
+# dependencies (e.g., a Python C extension depending on libm.so).
+
+PROGRAM_NAME := dlfcn-needed-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS) libs-all
+	$(CC) $(LDFLAGS) -pie -rdynamic -Wl,--no-dynamic-linker $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean: libs-clean
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+# libconsumer.so is linked with -lprovider (creates DT_NEEDED entry).
+libs-all:
+	$(CC) libs/provider.c -shared -fPIC -o $(LIBRARIES_DIR)/libprovider.so
+	$(CC) libs/consumer.c -shared -fPIC -L$(LIBRARIES_DIR) -lprovider -o $(LIBRARIES_DIR)/libconsumer.so
+
+libs-clean:
+	rm -f $(LIBRARIES_DIR)/libprovider.so
+	rm -f $(LIBRARIES_DIR)/libconsumer.so
+
+%.o: %.c
+	$(CC) $(CFLAGS) -fPIE $< -c -o $@

--- a/src/dlfcn-needed-c/libs/consumer.c
+++ b/src/dlfcn-needed-c/libs/consumer.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libconsumer.so - Shared library that depends on libprovider.so.
+ *
+ * Calls provider_add(), provider_mul(), provider_isqrt() which are
+ * defined in libprovider.so.  This library is linked against
+ * libprovider.so at build time, creating a DT_NEEDED entry.
+ *
+ * When the dynamic loader opens this library, it should automatically
+ * load libprovider.so (via DT_NEEDED) and resolve the symbols.
+ * This is the standard mechanism for shared library dependencies
+ * (e.g., a Python C extension depending on libm.so or libc.so).
+ */
+
+extern int provider_add(int a, int b);
+extern int provider_mul(int a, int b);
+extern int provider_isqrt(int x);
+
+int consumer_add(int a, int b)
+{
+    return provider_add(a, b);
+}
+
+int consumer_mul(int a, int b)
+{
+    return provider_mul(a, b);
+}
+
+int consumer_isqrt(int x)
+{
+    return provider_isqrt(x);
+}
+
+/* Function with no cross-library dependency (control case). */
+int consumer_noop(int x)
+{
+    return x + 1;
+}

--- a/src/dlfcn-needed-c/libs/provider.c
+++ b/src/dlfcn-needed-c/libs/provider.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * libprovider.so - Self-contained shared library that exports functions.
+ *
+ * All functions are implemented inline with no external dependencies,
+ * so this library has ZERO undefined symbols and always loads successfully.
+ */
+
+int provider_add(int a, int b)
+{
+    return a + b;
+}
+
+int provider_mul(int a, int b)
+{
+    return a * b;
+}
+
+/* Integer square root via Newton's method. */
+int provider_isqrt(int x)
+{
+    if (x <= 0)
+        return 0;
+    int r = x;
+    while (r > x / r)
+        r = (r + x / r) / 2;
+    return r;
+}

--- a/src/dlfcn-needed-c/main.c
+++ b/src/dlfcn-needed-c/main.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * dlfcn-needed-c: Test DT_NEEDED automatic dependency loading.
+ *
+ * This is the most common shared library pattern: libconsumer.so is
+ * linked against libprovider.so at build time, creating a DT_NEEDED
+ * entry.  When the loader opens libconsumer.so, it should automatically
+ * load libprovider.so and resolve all symbols.
+ *
+ * This is how real-world dependencies work:
+ *   - CPython C extensions have DT_NEEDED entries for libm.so, libc.so
+ *   - The dynamic linker loads those automatically
+ *   - No RTLD_GLOBAL or manual pre-loading is needed
+ *
+ * On Nanvix, this tests whether the ELF loader follows DT_NEEDED
+ * entries and loads transitive dependencies.
+ */
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 1: Load libprovider.so directly.
+ * Expected: PASS (no undefined symbols).
+ */
+static void test_provider_loads(void)
+{
+    void *h = dlopen("lib/libprovider.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("provider loads", dlerror());
+        return;
+    }
+
+    int (*fn)(int, int) = NULL;
+    *(void **)(&fn) = dlsym(h, "provider_add");
+    if (fn == NULL || fn(2, 3) != 5) {
+        fail("provider loads", "provider_add() wrong result");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("provider loads");
+}
+
+/*
+ * Test 2: Load libconsumer.so (which has DT_NEEDED: libprovider.so).
+ *
+ * The loader should automatically load libprovider.so via DT_NEEDED,
+ * resolve provider_add/mul/isqrt, and make consumer functions work.
+ *
+ * This is the standard pattern for how shared libraries depend on
+ * each other (e.g., a .so depending on libc.so or libm.so).
+ */
+static void test_consumer_with_needed(void)
+{
+    printf("  [2a] loading consumer (has DT_NEEDED: libprovider.so)...\n");
+    fflush(stdout);
+
+    void *h = dlopen("lib/libconsumer.so", RTLD_NOW);
+
+    printf("  [2b] dlopen returned %p\n", (void *)h);
+    fflush(stdout);
+
+    if (h == NULL) {
+        fail("DT_NEEDED auto-load", dlerror());
+        return;
+    }
+
+    /* Verify consumer functions work (they delegate to provider) */
+    int (*cadd)(int, int) = NULL;
+    *(void **)(&cadd) = dlsym(h, "consumer_add");
+    if (cadd == NULL || cadd(10, 20) != 30) {
+        fail("DT_NEEDED auto-load", "consumer_add() failed");
+        dlclose(h);
+        return;
+    }
+
+    int (*cmul)(int, int) = NULL;
+    *(void **)(&cmul) = dlsym(h, "consumer_mul");
+    if (cmul == NULL || cmul(6, 7) != 42) {
+        fail("DT_NEEDED auto-load", "consumer_mul() failed");
+        dlclose(h);
+        return;
+    }
+
+    int (*cisqrt)(int) = NULL;
+    *(void **)(&cisqrt) = dlsym(h, "consumer_isqrt");
+    if (cisqrt == NULL || cisqrt(9) != 3) {
+        fail("DT_NEEDED auto-load", "consumer_isqrt() failed");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("DT_NEEDED auto-load");
+}
+
+/*
+ * Test 3: consumer_noop() has no cross-lib dependency (control test).
+ */
+static void test_consumer_noop(void)
+{
+    void *h = dlopen("lib/libconsumer.so", RTLD_LAZY);
+    if (h == NULL) {
+        fail("consumer_noop (no cross-lib dep)", dlerror());
+        return;
+    }
+
+    int (*fn)(int) = NULL;
+    *(void **)(&fn) = dlsym(h, "consumer_noop");
+    if (fn == NULL || fn(41) != 42) {
+        fail("consumer_noop (no cross-lib dep)", "wrong result");
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("consumer_noop (no cross-lib dep)");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn DT_NEEDED tests ===\n");
+    fflush(stdout);
+
+    test_provider_loads();
+    test_consumer_with_needed();
+    test_consumer_noop();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 3);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Add two test suites for cross-`.so` symbol resolution, covering the two standard mechanisms: `DT_NEEDED` (automatic dependency loading) and `RTLD_GLOBAL` (global scope propagation).

Both suites use the same two shared libraries:
- **`libprovider.so`** — self-contained (zero undefined symbols), exports `provider_add()`, `provider_mul()`, `provider_isqrt()`
- **`libconsumer.so`** — calls `provider_add()` etc. (3 undefined symbols that must resolve from `libprovider.so`)

---

## Suite 1: `dlfcn-needed-c` — DT_NEEDED (standard pattern)

**What it tests:** `libconsumer.so` is linked against `libprovider.so` at build time, creating a `DT_NEEDED` entry. When the loader opens `libconsumer.so`, it should automatically load `libprovider.so` and resolve all symbols. This is the standard mechanism for shared library dependencies — how CPython C extensions depend on `libm.so` / `libc.so`.

**Verified results:**
`
=== dlfcn DT_NEEDED tests ===
  PASS: provider loads
  [2a] loading consumer (has DT_NEEDED: libprovider.so)...
  [2b] dlopen returned 0x0
  FAIL: DT_NEEDED auto-load (vfs open failed)
  PASS: consumer_noop (no cross-lib dep)
2 passed, 1 failed
`

**Bug:** The loader finds the `DT_NEEDED` entry for `libprovider.so` and tries to load it, but fails with `vfs open failed` — it cannot locate the file because the `DT_NEEDED` entry contains just the library name (`libprovider.so`), not the path (`lib/libprovider.so`). The loader needs a library search path mechanism (e.g., `LD_LIBRARY_PATH` equivalent, or searching the same directory as the requesting `.so`).

---

## Suite 2: `dlfcn-global-c` — RTLD_GLOBAL (plugin pattern)

**What it tests:** `libconsumer.so` is NOT linked against `libprovider.so` (no `DT_NEEDED`). The test loads `libprovider.so` with `RTLD_GLOBAL` first, then loads `libconsumer.so`. Per POSIX, `RTLD_GLOBAL` should make a library's symbols available for symbol resolution of subsequently loaded libraries.

**Verified results:**
`
=== dlfcn RTLD_GLOBAL tests ===
  PASS: consumer alone fails
  [2a] loading provider with RTLD_GLOBAL...
  [2b] provider loaded, loading consumer...
  [2c] consumer dlopen returned 0x400
  <crash: exit code 3>
`

**Bugs:**
1. **`RTLD_GLOBAL` has no effect** — provider symbols are not added to the global scope for use by subsequently loaded libraries.
2. **`dlopen` silently succeeds with unresolved relocations** — returns a valid handle (`0x400`) instead of NULL, leaving unpatched relocations that crash when the function is called.

---

## Context

These bugs block loading CPython C extensions (NumPy, lxml) on Nanvix. On Linux, extension `.so` files resolve libc/libm symbols via `DT_NEEDED` entries for `libc.so.6`/`libm.so.6`. On Nanvix, only static `libc.a`/`libm.a` exist, so neither `DT_NEEDED` nor `RTLD_GLOBAL` can provide the missing symbols.