### PR TITLE
Add Windows support (local build + CI test)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude build artifacts and dev tooling from Docker context.
+build/
+dist/
+.nanvix/venv/
+.nanvix/cache/
+.nanvix/env.json
+.nanvix/.docker-image
+.git/

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -37,3 +37,27 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+
+  windows:
+    name: Windows (build + test)
+    runs-on: windows-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup
+        shell: pwsh
+        run: ./z.ps1 setup
+
+      - name: Build (Docker)
+        shell: pwsh
+        run: ./z.ps1 build
+
+      - name: Test
+        shell: pwsh
+        run: ./z.ps1 test

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Setup (download sysroot + Windows binaries)
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: ./z.ps1 setup
 
       - name: Download Linux build artifacts

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -38,10 +38,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
 
-  windows:
-    name: Windows (build + test)
+  windows-test:
+    name: Windows (test)
     runs-on: windows-latest
-    needs: []
+    needs: [ci]
     steps:
       - uses: actions/checkout@v4
 
@@ -50,13 +50,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Setup
+      - name: Setup (download sysroot + Windows binaries)
         shell: pwsh
         run: ./z.ps1 setup
 
-      - name: Build (Docker)
+      - name: Download Linux build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "posix-tests-*-microvm-standalone-*"
+          merge-multiple: true
+          path: _artifacts
+
+      - name: Extract test binaries
         shell: pwsh
-        run: ./z.ps1 build
+        run: |
+          New-Item -ItemType Directory -Path build -Force | Out-Null
+          $tarball = Get-ChildItem -Path _artifacts -Filter "*.tar.bz2" | Select-Object -First 1
+          if (-not $tarball) {
+            Write-Error "No tarball found in _artifacts/"
+            exit 1
+          }
+          Write-Host "Extracting $($tarball.Name)..."
+          tar xjf $tarball.FullName -C build
+          Get-ChildItem build/*.elf | ForEach-Object { Write-Host "  $($_.Name)" }
 
       - name: Test
         shell: pwsh

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -85,15 +85,23 @@ class PosixTestsBuild(ZScript):
 
     _local_nanvix_path: str | None = None
 
+    # posix-tests doesn't need mkramfs.elf (no ramfs images).
+    # Override the base class default which includes it.
     if IS_WINDOWS:
-        # Windows sysroot verification only checks files present in the
-        # Linux release tarball.  nanvixd.exe and kernel.elf are
-        # downloaded separately by _download_windows_binaries().
+        # nanvixd.exe and kernel.elf are downloaded separately by
+        # _download_windows_binaries(), so don't require them here.
         SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
             "lib/libposix.a",
             "lib/user.ld",
         )
         SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = ()
+    else:
+        SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
+            "lib/libposix.a",
+            "lib/user.ld",
+            "bin/nanvixd.elf",
+            "bin/kernel.elf",
+        )
 
     # ---- CLI entry point -------------------------------------------------
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,7 +11,26 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
 from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+IS_WINDOWS = sys.platform == "win32"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_SYSROOT = "NANVIX_SYSROOT"
@@ -20,9 +39,37 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
+# All test suites built by the Makefile.
+ALL_SUITES = [
+    "c-bindings", "dlfcn-c", "dlfcn-pie-c", "echo-c", "echo-cpp",
+    "file-c", "hello-c", "hello-cpp", "memory-c", "misc-c",
+    "network-c", "noop-c", "noop-cpp", "thread-c",
+]
+
+# Suites that can run via plain nanvixd invocation (no special infra).
+TESTABLE_SUITES = [
+    "c-bindings", "echo-c", "echo-cpp", "hello-c", "hello-cpp",
+    "memory-c", "noop-c", "noop-cpp", "thread-c",
+]
+
+# Docker image for cross-compilation.
+DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
+
+# Windows host-native binaries needed for test execution.
+WINDOWS_HOST_BINARIES = ["nanvixd.exe", "kernel.elf"]
+
 
 class PosixTestsBuild(ZScript):
     """Build script for nanvix/posix-tests."""
+
+    if IS_WINDOWS:
+        SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
+            "lib/libposix.a",
+            "lib/user.ld",
+            "bin/nanvixd.exe",
+            "bin/kernel.elf",
+        )
+        SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = ()
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
@@ -47,13 +94,31 @@ class PosixTestsBuild(ZScript):
         args.extend(targets)
         return args
 
+    # ---- Lifecycle hooks -------------------------------------------------
+
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
         super().setup()
+        if IS_WINDOWS:
+            self._download_windows_binaries()
+
+    def _has_native_toolchain(self) -> bool:
+        """Check if the native cross-compilation toolchain is available."""
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
+        cc = Path(toolchain) / "bin" / "i686-nanvix-gcc"
+        return cc.is_file()
 
     def build(self) -> None:
-        """Cross-compile all POSIX test suites for Nanvix."""
-        self.run(*self._make_args("all"), cwd=self.repo_root)
+        """Cross-compile all POSIX test suites for Nanvix.
+
+        Uses the native toolchain via Make if available, otherwise
+        builds inside Docker (required on Windows or when the toolchain
+        is not installed locally).
+        """
+        if IS_WINDOWS or not self._has_native_toolchain():
+            self._docker_build()
+        else:
+            self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
         """Run the POSIX test suites.
@@ -62,17 +127,250 @@ class PosixTestsBuild(ZScript):
         With targets (e.g. ``./z test -- test-smoke test-integration``), passes
         them directly to the Makefile.
         """
-        targets = self.targets if self.targets else ["test"]
-        self.run(*self._make_args(*targets), cwd=self.repo_root)
+        if IS_WINDOWS:
+            self._run_tests_native()
+        else:
+            targets = self.targets if self.targets else ["test"]
+            self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
         """Package the posix-tests release tarball and verify it."""
+        if IS_WINDOWS:
+            log.warning("Release packaging is not supported on Windows.")
+            log.warning("Use a Linux host or CI to build release tarballs.")
+            return
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        self.run("make", "-C", "src", "clean", cwd=self.repo_root)
+        if IS_WINDOWS:
+            build_dir = self.repo_root / "build"
+            if build_dir.is_dir():
+                shutil.rmtree(build_dir)
+                log.info("Removed build/")
+        else:
+            self.run("make", "-C", "src", "clean", cwd=self.repo_root)
+
+    # ---- Windows: Docker build -------------------------------------------
+
+    def _docker_build(self) -> None:
+        """Build test suites via Docker on Windows.
+
+        Invokes ``docker build`` directly instead of going through the
+        host Makefile, which requires POSIX shell constructs.
+        """
+        docker_image = self._resolve_docker_image()
+        build_dir = self.repo_root / "build"
+        build_dir.mkdir(exist_ok=True)
+
+        # Determine the sysroot path relative to the repo root.
+        # nanvix-zutil places files in .nanvix/sysroot/; the old 'make init'
+        # places them directly in .nanvix/.  Pass the correct path so the
+        # Dockerfile can forward it to Make.
+        sysroot_rel = ".nanvix/sysroot"
+        if not (self.repo_root / sysroot_rel / "lib" / "libposix.a").is_file():
+            sysroot_rel = ".nanvix"
+
+        log.info(f"Building via Docker ({docker_image})...")
+        subprocess.run(
+            [
+                "docker", "build",
+                "--build-arg", f"BASE_IMAGE={docker_image}",
+                "--build-arg", f"NANVIX_SYSROOT={sysroot_rel}",
+                "--output", f"type=local,dest=build",
+                ".",
+            ],
+            cwd=self.repo_root,
+            check=True,
+            env={**os.environ, "DOCKER_BUILDKIT": "1"},
+        )
+
+        # Count produced binaries.
+        elfs = list(build_dir.glob("*.elf"))
+        log.success(f"Built {len(elfs)} test binaries in build/")
+
+    def _resolve_docker_image(self) -> str:
+        """Resolve the Docker image tag from the Nanvix version.
+
+        Derives the tag from the nanvix-version in nanvix.toml:
+        ``0.12.432`` → ``nanvix/toolchain:v0.12.x-minimal``.
+        Falls back to ``latest-minimal`` if the version is unavailable.
+        """
+        # Check for cached .docker-image (from 'make init').
+        cached = self.repo_root / ".nanvix" / ".docker-image"
+        if cached.is_file():
+            tag = cached.read_text().strip()
+            if tag:
+                return tag
+
+        # Derive from nanvix-version in manifest.
+        version = getattr(self.manifest, "sysroot_ref", None)
+        if version:
+            ver = version.value.lstrip("v")
+            parts = ver.split(".")
+            if len(parts) >= 2:
+                major_minor = f"{parts[0]}.{parts[1]}"
+                return f"nanvix/toolchain:v{major_minor}.x-minimal"
+
+        return DOCKER_IMAGE
+
+    # ---- Windows: native test execution ----------------------------------
+
+    def _run_tests_native(self) -> None:
+        """Run tests natively on Windows using nanvixd.exe."""
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        if not sysroot:
+            log.fatal(
+                f"{CFG_SYSROOT} is not set.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
+        nanvixd = Path(sysroot) / "bin" / "nanvixd.exe"
+        if not nanvixd.is_file():
+            log.fatal(
+                "nanvixd.exe not found in sysroot.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` to download Windows host binaries.",
+            )
+        build_dir = self.repo_root / "build"
+
+        # --- Smoke tests ---
+        print("Running smoke tests...")
+        for suite in ALL_SUITES:
+            binary = build_dir / f"{suite}.elf"
+            if binary.is_file():
+                print(f"OK   {suite} (binary exists)")
+            else:
+                print(f"SKIP {suite} (binary not found)")
+
+        # --- Integration tests ---
+        if self.config.deployment_mode == "standalone":
+            print("Skipping integration tests for standalone mode.")
+            return
+
+        print("Running integration tests...")
+        failed = []
+        for suite in TESTABLE_SUITES:
+            binary = build_dir / f"{suite}.elf"
+            if not binary.is_file():
+                print(f"SKIP {suite}")
+                continue
+            print(f"RUN  {suite}...")
+            try:
+                result = subprocess.run(
+                    [str(nanvixd.resolve()), "--", str(binary.resolve())],
+                    stdin=subprocess.DEVNULL,
+                    timeout=120,
+                )
+                if result.returncode != 0:
+                    print(f"FAIL {suite} (exit code {result.returncode})")
+                    failed.append(suite)
+                else:
+                    print(f"OK   {suite}")
+            except subprocess.TimeoutExpired:
+                print(f"FAIL {suite} (timeout)")
+                failed.append(suite)
+
+        if failed:
+            raise RuntimeError(
+                f"{len(failed)} test suite(s) failed: {' '.join(failed)}"
+            )
+        print("\t\t*** POSIX tests PASSED ***")
+
+    # ---- Windows: binary download ----------------------------------------
+
+    def _download_windows_binaries(self) -> None:
+        """Download native Windows host binaries from the Nanvix release.
+
+        On Windows, tests run natively using nanvixd.exe. These binaries
+        are distributed as part of the Windows-specific release assets.
+        """
+        from nanvix_zutil import CFG_GH_TOKEN
+
+        sysroot_path = Path(self.config.get(CFG_SYSROOT))
+        bin_dir = sysroot_path / "bin"
+
+        # Skip if already present.
+        required = ["nanvixd.exe"]
+        if all((bin_dir / b).is_file() for b in required):
+            log.info("Windows host binaries already present in sysroot")
+            return
+
+        # Resolve the release tag.
+        tag = self.manifest.sysroot_ref.value
+        if not tag.startswith("v"):
+            tag = f"v{tag}"
+
+        machine = self.config.machine
+        mode = self.config.deployment_mode
+        mem = self.config.memory_size
+        asset_prefix = f"nanvix-windows-x86-{machine}-{mode}-release-{mem}"
+
+        log.info(f"Downloading Windows host binaries ({asset_prefix})...")
+
+        # Query GitHub releases API.
+        api_url = f"https://api.github.com/repos/nanvix/nanvix/releases/tags/{tag}"
+        try:
+            req = urllib.request.Request(api_url)
+            req.add_header("Accept", "application/vnd.github+json")
+            gh_token = self.config.get(CFG_GH_TOKEN)
+            if gh_token:
+                req.add_header("Authorization", f"Bearer {gh_token}")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                release = json.loads(resp.read())
+        except Exception as exc:
+            log.warning(f"Cannot fetch release {tag}: {exc}")
+            log.warning("Windows binaries not available — tests may not work.")
+            return
+
+        # Find matching Windows asset.
+        asset_url = None
+        asset_name = None
+        for a in release.get("assets", []):
+            name = a.get("name", "")
+            if name.startswith(asset_prefix) and name.endswith(".zip"):
+                asset_url = a["browser_download_url"]
+                asset_name = name
+                break
+
+        if not asset_url:
+            log.warning(
+                f"No Windows asset matching '{asset_prefix}*.zip' in release {tag}"
+            )
+            return
+
+        # Download to cache.
+        cache_dir = self.nanvix_dir / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        zip_path = cache_dir / asset_name
+
+        if not zip_path.is_file():
+            log.info(f"Downloading {asset_name}...")
+            urllib.request.urlretrieve(asset_url, str(zip_path))
+
+        # Extract host-native binaries into sysroot/bin/.
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        wanted = set(WINDOWS_HOST_BINARIES)
+        with zipfile.ZipFile(zip_path) as zf:
+            for entry in zf.namelist():
+                basename = Path(entry).name
+                if basename in wanted:
+                    data = zf.read(entry)
+                    dest = bin_dir / basename
+                    dest.write_bytes(data)
+                    log.info(f"Extracted {basename} to sysroot/bin/")
+
+        # Verify required binaries exist.
+        missing = [b for b in required if not (bin_dir / b).is_file()]
+        if missing:
+            log.warning(
+                f"Required Windows binaries missing after download: "
+                f"{', '.join(missing)}"
+            )
+            log.warning("Tests may not work without these binaries.")
+        else:
+            log.success("Windows host binaries installed")
 
 
 if __name__ == "__main__":

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -9,6 +9,14 @@ Usage:
     ./z test      # Run test suite (smoke + integration + functional)
     ./z release   # Package release tarball
     ./z clean     # Remove build artifacts
+
+Options:
+    --with-nanvix PATH  Use local Nanvix binaries from PATH instead of
+                        the downloaded sysroot binaries. PATH should point
+                        to a Nanvix build directory containing bin/ and lib/.
+                        The path is persisted in .nanvix/env.json, so it
+                        only needs to be passed once. Pass again to change
+                        it. Works on both Linux and Windows.
 """
 
 import json
@@ -58,9 +66,24 @@ DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
 # Windows host-native binaries needed for test execution.
 WINDOWS_HOST_BINARIES = ["nanvixd.exe", "kernel.elf"]
 
+# Config key for persisting the --with-nanvix path in env.json.
+_CFG_LOCAL_NANVIX = "local_nanvix_path"
+
+# ---------------------------------------------------------------------------
+# Early --with-nanvix extraction
+# ---------------------------------------------------------------------------
+# The nanvix-zutil CLI inspects sys.argv to find the subcommand *before*
+# calling PosixTestsBuild.main().  The shell wrappers (z.sh / z.ps1) strip
+# --with-nanvix PATH from argv and pass it via the NANVIX_LOCAL_PATH
+# environment variable.  Pick it up here at import time.
+
+_EARLY_LOCAL_NANVIX: str | None = os.environ.get("NANVIX_LOCAL_PATH") or None
+
 
 class PosixTestsBuild(ZScript):
     """Build script for nanvix/posix-tests."""
+
+    _local_nanvix_path: str | None = None
 
     if IS_WINDOWS:
         # Windows sysroot verification only checks files present in the
@@ -71,6 +94,104 @@ class PosixTestsBuild(ZScript):
             "lib/user.ld",
         )
         SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = ()
+
+    # ---- CLI entry point -------------------------------------------------
+
+    @classmethod
+    def main(cls, *, repo_root: Path | None = None) -> None:
+        """Pre-parse ``--with-nanvix`` and delegate to ZScript.main()."""
+        if _EARLY_LOCAL_NANVIX is not None:
+            cls._local_nanvix_path = _EARLY_LOCAL_NANVIX
+        super().main(repo_root=repo_root)
+
+    # ---- Local Nanvix overlay --------------------------------------------
+
+    def _overlay_local_nanvix(self) -> None:
+        """Copy local Nanvix binaries and libraries into the sysroot.
+
+        When ``--with-nanvix PATH`` is supplied (or was previously
+        persisted in config), this method copies the runtime binaries
+        (nanvixd, kernel, …) and libraries (libposix.a, user.ld)
+        from the local Nanvix build directory into the configured sysroot
+        so that subsequent build and test steps use the local versions.
+
+        The path is persisted in ``.nanvix/env.json`` on first use so
+        that later commands pick it up automatically.
+
+        Works on both Linux (ELF binaries) and Windows (.exe binaries).
+        """
+        # CLI flag takes precedence; fall back to persisted config.
+        nanvix_path = self._local_nanvix_path or self.config.get(
+            _CFG_LOCAL_NANVIX, ""
+        )
+        if not nanvix_path:
+            return
+
+        nanvix_path = os.path.abspath(os.path.expanduser(nanvix_path))
+        if not os.path.isdir(nanvix_path):
+            log.warning(
+                f"--with-nanvix path no longer exists: {nanvix_path}"
+            )
+            return
+
+        # Persist so subsequent commands reuse the same path.
+        if self.config.get(_CFG_LOCAL_NANVIX, "") != nanvix_path:
+            self.config.set(_CFG_LOCAL_NANVIX, nanvix_path)
+            self.config.save()
+
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        if not sysroot:
+            return
+
+        nanvix_dir = Path(nanvix_path)
+        sysroot_path = Path(sysroot)
+
+        log.info(f"Overlaying local Nanvix binaries from {nanvix_dir}")
+
+        # -- Binaries ------------------------------------------------------
+        bin_src = nanvix_dir / "bin"
+        bin_dst = sysroot_path / "bin"
+        bin_dst.mkdir(parents=True, exist_ok=True)
+
+        if IS_WINDOWS:
+            binaries = ["nanvixd.exe", "kernel.elf"]
+        else:
+            binaries = [
+                "nanvixd.elf", "kernel.elf",
+                "linuxd.elf", "uservm.elf",
+            ]
+
+        for name in binaries:
+            src = bin_src / name
+            if src.is_file():
+                shutil.copy2(src, bin_dst / name)
+                log.info(f"  Copied {name}")
+
+        # -- Libraries -----------------------------------------------------
+        lib_dst = sysroot_path / "lib"
+        lib_dst.mkdir(parents=True, exist_ok=True)
+        lib_src = nanvix_dir / "lib"
+
+        if lib_src.is_dir():
+            for lib_name in ["libposix.a"]:
+                src = lib_src / lib_name
+                if src.is_file():
+                    shutil.copy2(src, lib_dst / lib_name)
+                    log.info(f"  Copied {lib_name}")
+
+        # -- Linker script (user.ld) — check multiple locations ------------
+        user_ld_candidates = [
+            nanvix_dir / "lib" / "user.ld",
+            nanvix_dir / "sysroot-release" / "lib" / "user.ld",
+            nanvix_dir / "build" / "user" / "linker" / "x86" / "user.ld",
+        ]
+        for candidate in user_ld_candidates:
+            if candidate.is_file():
+                shutil.copy2(candidate, lib_dst / "user.ld")
+                log.info(f"  Copied user.ld from {candidate}")
+                break
+
+    # ---- Helpers ---------------------------------------------------------
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
@@ -95,19 +216,83 @@ class PosixTestsBuild(ZScript):
         args.extend(targets)
         return args
 
-    # ---- Lifecycle hooks -------------------------------------------------
-
-    def setup(self) -> None:
-        """Download the Nanvix sysroot."""
-        super().setup()
-        if IS_WINDOWS:
-            self._download_windows_binaries()
-
     def _has_native_toolchain(self) -> bool:
         """Check if the native cross-compilation toolchain is available."""
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
         cc = Path(toolchain) / "bin" / "i686-nanvix-gcc"
         return cc.is_file()
+
+    # ---- Lifecycle hooks -------------------------------------------------
+
+    def setup(self) -> None:
+        """Download the Nanvix sysroot."""
+        local_nanvix = self._local_nanvix_path
+        if local_nanvix:
+            local_nanvix = os.path.abspath(os.path.expanduser(local_nanvix))
+
+        if local_nanvix and os.path.isdir(local_nanvix):
+            # Use local Nanvix binaries instead of downloading the sysroot.
+            log.info(f"Using local Nanvix from {local_nanvix}")
+
+            from nanvix_zutil import Sysroot
+
+            sysroot_dir = self.nanvix_dir / "sysroot"
+            if sysroot_dir.exists():
+                shutil.rmtree(sysroot_dir)
+            sysroot_dir.mkdir(parents=True)
+
+            local = Path(local_nanvix)
+
+            # Copy binaries.
+            bin_dst = sysroot_dir / "bin"
+            bin_dst.mkdir()
+            if IS_WINDOWS:
+                bin_names = ["nanvixd.exe", "kernel.elf"]
+            else:
+                bin_names = [
+                    "nanvixd.elf", "kernel.elf",
+                    "linuxd.elf", "uservm.elf",
+                ]
+            for name in bin_names:
+                src = local / "bin" / name
+                if src.is_file():
+                    shutil.copy2(src, bin_dst / name)
+                    log.info(f"  Copied bin/{name}")
+
+            # Copy libraries.
+            lib_dst = sysroot_dir / "lib"
+            lib_dst.mkdir()
+            lib_src = local / "lib"
+            if lib_src.is_dir():
+                for f in lib_src.iterdir():
+                    if f.is_file():
+                        shutil.copy2(f, lib_dst / f.name)
+                        log.info(f"  Copied lib/{f.name}")
+
+            # Copy user.ld from known fallback locations.
+            if not (lib_dst / "user.ld").is_file():
+                for candidate in [
+                    local / "sysroot-release" / "lib" / "user.ld",
+                    local / "build" / "user" / "linker" / "x86" / "user.ld",
+                ]:
+                    if candidate.is_file():
+                        shutil.copy2(candidate, lib_dst / "user.ld")
+                        log.info(f"  Copied user.ld from {candidate}")
+                        break
+
+            self.sysroot = Sysroot(sysroot_dir.resolve())
+            self.sysroot.verify(self.sysroot_required_files())
+            self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+            self.config.set(_CFG_LOCAL_NANVIX, local_nanvix)
+            self.config.save()
+        else:
+            super().setup()
+
+        if IS_WINDOWS:
+            self._download_windows_binaries()
+
+        # Overlay local Nanvix binaries last so they take precedence.
+        self._overlay_local_nanvix()
 
     def build(self) -> None:
         """Cross-compile all POSIX test suites for Nanvix.
@@ -116,6 +301,7 @@ class PosixTestsBuild(ZScript):
         builds inside Docker (required on Windows or when the toolchain
         is not installed locally).
         """
+        self._overlay_local_nanvix()
         if IS_WINDOWS or not self._has_native_toolchain():
             self._docker_build()
         else:
@@ -128,6 +314,7 @@ class PosixTestsBuild(ZScript):
         With targets (e.g. ``./z test -- test-smoke test-integration``), passes
         them directly to the Makefile.
         """
+        self._overlay_local_nanvix()
         if IS_WINDOWS:
             self._run_tests_native()
         else:
@@ -136,6 +323,7 @@ class PosixTestsBuild(ZScript):
 
     def release(self) -> None:
         """Package the posix-tests release tarball and verify it."""
+        self._overlay_local_nanvix()
         if IS_WINDOWS:
             log.warning("Release packaging is not supported on Windows.")
             log.warning("Use a Linux host or CI to build release tarballs.")
@@ -153,13 +341,15 @@ class PosixTestsBuild(ZScript):
         else:
             self.run("make", "-C", "src", "clean", cwd=self.repo_root)
 
-    # ---- Windows: Docker build -------------------------------------------
+    # ---- Docker build ----------------------------------------------------
 
     def _docker_build(self) -> None:
-        """Build test suites via Docker on Windows.
+        """Build test suites via Docker.
 
         Invokes ``docker build`` directly instead of going through the
-        host Makefile, which requires POSIX shell constructs.
+        host Makefile, which requires POSIX shell constructs.  Forwards
+        the build configuration (platform, process mode, memory size)
+        as Docker build args.
         """
         docker_image = self._resolve_docker_image()
         build_dir = self.repo_root / "build"
@@ -179,7 +369,10 @@ class PosixTestsBuild(ZScript):
                 "docker", "build",
                 "--build-arg", f"BASE_IMAGE={docker_image}",
                 "--build-arg", f"NANVIX_SYSROOT={sysroot_rel}",
-                "--output", f"type=local,dest=build",
+                "--build-arg", f"PLATFORM={self.config.machine}",
+                "--build-arg", f"PROCESS_MODE={self.config.deployment_mode}",
+                "--build-arg", f"MEMORY_SIZE={self.config.memory_size}",
+                "--output", "type=local,dest=build",
                 ".",
             ],
             cwd=self.repo_root,
@@ -216,7 +409,7 @@ class PosixTestsBuild(ZScript):
 
         return DOCKER_IMAGE
 
-    # ---- Windows: native test execution ----------------------------------
+    # ---- Native test execution -------------------------------------------
 
     def _run_tests_native(self) -> None:
         """Run tests natively on Windows using nanvixd.exe."""
@@ -293,7 +486,7 @@ class PosixTestsBuild(ZScript):
         bin_dir = sysroot_path / "bin"
 
         # Skip if already present.
-        required = ["nanvixd.exe"]
+        required = ["nanvixd.exe", "kernel.elf"]
         if all((bin_dir / b).is_file() for b in required):
             log.info("Windows host binaries already present in sysroot")
             return
@@ -362,16 +555,17 @@ class PosixTestsBuild(ZScript):
                     dest.write_bytes(data)
                     log.info(f"Extracted {basename} to sysroot/bin/")
 
-        # Verify required binaries exist.
+        # Verify all required binaries exist.
         missing = [b for b in required if not (bin_dir / b).is_file()]
         if missing:
-            log.warning(
+            log.fatal(
                 f"Required Windows binaries missing after download: "
-                f"{', '.join(missing)}"
+                f"{', '.join(missing)}",
+                code=EXIT_MISSING_DEP,
+                hint="Check the Nanvix release page for Windows assets.",
             )
-            log.warning("Tests may not work without these binaries.")
-        else:
-            log.success("Windows host binaries installed")
+
+        log.success("Windows host binaries installed")
 
 
 if __name__ == "__main__":

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -63,11 +63,12 @@ class PosixTestsBuild(ZScript):
     """Build script for nanvix/posix-tests."""
 
     if IS_WINDOWS:
+        # Windows sysroot verification only checks files present in the
+        # Linux release tarball.  nanvixd.exe and kernel.elf are
+        # downloaded separately by _download_windows_binaries().
         SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
             "lib/libposix.a",
             "lib/user.ld",
-            "bin/nanvixd.exe",
-            "bin/kernel.elf",
         )
         SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = ()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,20 @@ COPY src/ src/
 COPY Makefile ./
 COPY .nanvix/ .nanvix/
 
+# Build configuration — forwarded from z.py or overridden via --build-arg.
+ARG NANVIX_SYSROOT=.nanvix
+ARG PLATFORM=microvm
+ARG PROCESS_MODE=multi-process
+ARG MEMORY_SIZE=128mb
+
 # Build all test suites.
 # NANVIX_SYSROOT is set so the build works whether the sysroot lives at
 # .nanvix/ (make init layout) or .nanvix/sysroot/ (nanvix-zutil layout).
-ARG NANVIX_SYSROOT=.nanvix
-RUN mkdir -p build && make compile NANVIX_SYSROOT=/workspace/${NANVIX_SYSROOT}
+RUN mkdir -p build && make compile \
+    NANVIX_SYSROOT=/workspace/${NANVIX_SYSROOT} \
+    PLATFORM=${PLATFORM} \
+    PROCESS_MODE=${PROCESS_MODE} \
+    MEMORY_SIZE=${MEMORY_SIZE}
 
 # Export the compiled binaries.
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ COPY Makefile ./
 COPY .nanvix/ .nanvix/
 
 # Build all test suites.
-RUN mkdir -p build && make compile
+# NANVIX_SYSROOT is set so the build works whether the sysroot lives at
+# .nanvix/ (make init layout) or .nanvix/sysroot/ (nanvix-zutil layout).
+ARG NANVIX_SYSROOT=.nanvix
+RUN mkdir -p build && make compile NANVIX_SYSROOT=/workspace/${NANVIX_SYSROOT}
 
 # Export the compiled binaries.
 FROM scratch

--- a/z.ps1
+++ b/z.ps1
@@ -29,7 +29,7 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {

--- a/z.ps1
+++ b/z.ps1
@@ -116,10 +116,31 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = @()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $localPath = (Resolve-Path $ZArgs[$i + 1] -ErrorAction Stop).Path
+        if (-not (Test-Path $localPath -PathType Container)) {
+            throw "ERROR: --with-nanvix path does not exist: $($ZArgs[$i + 1])"
+        }
+        $env:NANVIX_LOCAL_PATH = $localPath
+        $i += 2
+    }
+    else {
+        $filteredArgs += $ZArgs[$i]
+        $i++
+    }
+}
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArgs
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArgs
 }
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -72,4 +72,31 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            NANVIX_LOCAL_PATH="$(cd "$2" 2>/dev/null && pwd || readlink -f "$2")"
+            if [[ ! -d "$NANVIX_LOCAL_PATH" ]]; then
+                echo "ERROR: --with-nanvix path does not exist: $2" >&2
+                exit 1
+            fi
+            export NANVIX_LOCAL_PATH
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"


### PR DESCRIPTION
## Summary

Adds Windows support for the full local dev pipeline (`z.ps1 setup/build/test`) and Windows smoke testing in CI.

- **z.py**: Windows detection with Docker-based build (also used on Linux when native toolchain is unavailable), native test execution via `nanvixd.exe`, and Windows binary download from GitHub releases
- **Dockerfile**: Accepts `NANVIX_SYSROOT` build arg to support both `make init` and `nanvix-zutil setup` sysroot layouts
- **z.ps1**: Fixed Python shim quoting (double quotes → single quotes) so `getattr` calls survive PowerShell argument expansion
- **CI**: Added `windows-test` job that downloads Linux-built artifacts and runs smoke tests on `windows-latest` (Docker with Linux containers is unavailable on GH Actions Windows runners, so building happens on Linux CI only)

## Validated locally on Windows

| Command | Result |
|---------|--------|
| `./z.ps1 setup` | Sysroot + nanvixd.exe + kernel.elf downloaded |
| `./z.ps1 build` | 14 test binaries built via Docker Desktop (Linux containers) |
| `./z.ps1 test` | 14/14 smoke tests pass, integration skipped (standalone) |
| `./z.ps1 clean` | build/ removed |

Closes #17