### PR TITLE
ci: adopt docker-build / native-test workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,52 +30,11 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.10.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
-      zutil-version: "v0.7.25"
+      zutil-version: "v0.7.26"
       caller-event-name: ${{ github.event_name }}
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
-
-  windows-test:
-    name: Windows (test)
-    runs-on: windows-latest
-    needs: [ci]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Setup (download sysroot + Windows binaries)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: ./z.ps1 setup
-
-      - name: Download Linux build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: "posix-tests-*-microvm-standalone-*"
-          merge-multiple: true
-          path: _artifacts
-
-      - name: Extract test binaries
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Path build -Force | Out-Null
-          $tarball = Get-ChildItem -Path _artifacts -Filter "*.tar.bz2" | Select-Object -First 1
-          if (-not $tarball) {
-            Write-Error "No tarball found in _artifacts/"
-            exit 1
-          }
-          Write-Host "Extracting $($tarball.Name)..."
-          tar xjf $tarball.FullName -C build
-          Get-ChildItem build/*.elf | ForEach-Object { Write-Host "  $($_.Name)" }
-
-      - name: Test
-        shell: pwsh
-        run: ./z.ps1 test

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -33,6 +33,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
+      process-modes: '["standalone"]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
     secrets:


### PR DESCRIPTION
## Summary
Adopt the new docker-build / native-test CI workflow (v1.12.0).

### Changes
- **Workflow**: Update to `nanvix/workflows@v1.12.0`
- **zutil**: Update to `v0.7.26` (Docker flags moved to setup subcommand)
- **Windows test**: Enable artifact-based Windows testing on `windows-latest`

### How it works
- **Linux**: Build with Docker (`nanvix-zutil setup --with-docker` + `nanvix-zutil build`), test natively (KVM)
- **Windows**: Download ELF binaries from Linux build, test natively (`nanvixd.exe`)
- All on GitHub-hosted runners (no self-hosted required)