### PR TITLE
Enable single-process and multi-process modes in CI

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -33,7 +33,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
-      process-modes: "[\"standalone\"]"
+      process-modes: "[\"standalone\",\"single-process\",\"multi-process\"]"
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}
       windows-test: true


### PR DESCRIPTION
Enable build, test, and CI support for 128MB across all platform/mode combinations:

| Platform | Mode | Memory | OS |
|---|---|---|---|
| hyperlight | standalone | 128mb | Linux + Windows |
| hyperlight | single-process | 128mb | Linux only |
| hyperlight | multi-process | 128mb | Linux only |
| microvm | standalone | 128mb | Linux + Windows |
| microvm | single-process | 128mb | Linux only |
| microvm | multi-process | 128mb | Linux only |

Previously CI only ran standalone mode. This expands `process-modes` to include `single-process` and `multi-process`. Windows tests remain standalone-only (multi-process requires linuxd which is Linux-only).