### PR TITLE
ci: add format & lint job via zutils reusable workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -29,6 +29,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format-and-lint:
+    uses: nanvix/workflows/.github/workflows/nanvix-format-lint.yml@v1.13.0
+    with:
+      zutil-version: "v0.7.41"
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:


### PR DESCRIPTION
Adds a `format-and-lint` job that calls `nanvix/zutils/.github/workflows/nanvix-ci.yml` to check Python formatting (black), type-checking (pyright), shell formatting (shfmt), shell linting (shellcheck), and YAML linting (yamllint).

Depends on: https://github.com/nanvix/zutils/pull/159