### PR TITLE
ci: bump nanvix/workflows to v1.14.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.42"
       process-modes: "[\"standalone\",\"single-process\",\"multi-process\"]"

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -16,7 +16,7 @@ on:
       - "nanvix/**"
   workflow_dispatch:
   repository_dispatch:
-    types: [ nanvix-minor-release, nanvix-major-release ]
+    types: [nanvix-minor-release, nanvix-major-release]
 
 permissions:
   contents: write


### PR DESCRIPTION
Bumps `nanvix/workflows` from `v1.13.0` to `v1.14.0`, which adds format & lint checks (black, pyright, shfmt, shellcheck, yamllint) to the `nanvix-ci.yml` reusable workflow.

All consumers automatically gain these checks with no other changes needed.