### PR TITLE
[ci] Sync zutils v0.7.43

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -32,7 +32,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
-      zutil-version: "v0.7.43"
+      zutil-version: "v0.7.44"
       process-modes: "[\"standalone\",\"single-process\",\"multi-process\"]"
       skip-full-test-modes: "[]"
       caller-event-name: ${{ github.event_name }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posix-tests"
 version = "0.1.0"
-nanvix-version = "0.12.511"
+nanvix-version = "0.12.521"
 
 [builds]
 [builds.matrix]

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.43"
+    "0.7.44"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -155,4 +155,14 @@ if ($bin -eq $venvZutil) {
 else {
     & $bin @filteredArray
 }
-exit $LASTEXITCODE
+
+$ec = $LASTEXITCODE
+
+# On Windows the venv's python.exe is locked while it runs, so the Python
+# distclean command cannot delete it.  Now that the interpreter has exited the
+# lock is released and the shell can safely remove the venv directory.
+if ($filteredArray -and $filteredArray[0] -eq "distclean" -and (Test-Path $venvDir)) {
+    Remove-Item $venvDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit $ec

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.43"
+PINNED_VERSION="0.7.44"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -106,5 +106,17 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
+# so the Python distclean command cannot delete it.  Run without exec so the
+# shell can remove the venv after the interpreter exits.
+if [[ "${ARGS[0]:-}" == "distclean" ]]; then
+    "$BIN" "${ARGS[@]}"
+    EC=$?
+    if [ -d "$VENV" ]; then
+        rm -rf "$VENV" 2>/dev/null || true
+    fi
+    exit $EC
+fi
 
 exec "$BIN" "${ARGS[@]}"


### PR DESCRIPTION
Automated sync with [`v0.7.43`](https://github.com/nanvix/zutils/releases/tag/v0.7.43):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.521` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.