### PR TITLE
[ci] Enable Hyperlight standalone builds

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -32,9 +32,14 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
-      zutil-version: "v0.7.43"
-      process-modes: "[\"standalone\",\"single-process\",\"multi-process\"]"
-      skip-full-test-modes: "[]"
+      zutil-version: "v0.7.44"
+      platforms: '["hyperlight","microvm"]'
+      process-modes: '["multi-process","single-process","standalone"]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+        {"platform":"hyperlight","process-mode":"single-process"}]
+      windows-matrix-exclude: '[]'
+      skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
     secrets:

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posix-tests"
 version = "0.1.0"
-nanvix-version = "0.12.511"
+nanvix-version = "0.12.521"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
## Summary

- Enable Hyperlight platform in CI alongside microvm
- Exclude `multi-process` and `single-process` modes for Hyperlight (only `standalone` works currently)
- Bump nanvix-version to 0.12.521 (includes Hyperlight HAL frame allocator fix)
- Bump zutil to v0.7.44

## Issues

- Closes #92 