### PR TITLE
Add CODEOWNERS file to auto-request reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @ppenna


### PR DESCRIPTION
This adds a `.github/CODEOWNERS` file so that @ppenna is automatically requested as a reviewer on all pull requests.

**Problem:** PR #99 was merged without review or notification because there was no CODEOWNERS file and no reviewers were requested.

**Fix:** With this file, GitHub will auto-assign @ppenna as a reviewer on every PR, ensuring proper notification and review coverage.