### PR TITLE
[ci] E: Update nanvix workflow refs to v1.15.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,7 @@ MEMORY_SIZE ?= 128mb
 # Cross-compiler.
 export CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
 export CXX := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-g++
+export READELF := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-readelf
 
 # Compiler flags.
 export CFLAGS := -std=c17

--- a/src/Makefile
+++ b/src/Makefile
@@ -135,19 +135,19 @@ DIST_DIR := $(CURDIR)/../dist
 package: all
 	@echo "Packaging release..."
 	mkdir -p $(DIST_DIR)
-	tar cjf $(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.bz2 \
+	tar czf $(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.gz \
 		-C $(BINARIES_DIR) $(addsuffix .elf,$(SUITES))
-	@echo "Package: $(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.bz2"
+	@echo "Package: $(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.gz"
 
 verify-package:
 	@echo "Verifying package..."
-	@tarball="$(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.bz2"; \
+	@tarball="$(DIST_DIR)/posix-tests-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE).tar.gz"; \
 	if [ ! -f "$$tarball" ]; then \
 		echo "ERROR: Package not found: $$tarball"; \
 		exit 1; \
 	fi; \
 	for suite in $(SUITES); do \
-		if ! tar tjf "$$tarball" | grep -q "$${suite}.elf"; then \
+		if ! tar tzf "$$tarball" | grep -q "$${suite}.elf"; then \
 			echo "ERROR: Missing $${suite}.elf in package"; \
 			exit 1; \
 		fi; \

--- a/src/dlfcn-c/Makefile
+++ b/src/dlfcn-c/Makefile
@@ -20,7 +20,7 @@ clean: libs-clean
 libs-all:
 	$(CC) libs/mul.c -shared -fPIC -o $(LIBRARIES_DIR)/libmul.so
 	@for TYPE in $(REQUIRED_TYPES); do \
-	if ! readelf -r $(LIBRARIES_DIR)/libmul.so | grep -q $$TYPE; then \
+	if ! $(READELF) -r $(LIBRARIES_DIR)/libmul.so | grep -q $$TYPE; then \
 	echo "Error: Relocation type $$TYPE not found in $(LIBRARIES_DIR)/libmul.so"; \
 	exit 1; \
 	fi \


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.15.0`](https://github.com/nanvix/workflows/releases/tag/v1.15.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.