### PR TITLE
fix: update docker image resolution in init target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,9 @@ $(NANVIX_DIR)/lib/libposix.a:
 		--jq '.content' 2>/dev/null | base64 -d) || true; \
 	CARGO_VERSION=$$(echo "$$CARGO_TOML" | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/') || true; \
 	if [ -n "$$CARGO_VERSION" ]; then \
-		MAJOR_MINOR="$${CARGO_VERSION%.*}"; \
-		DOCKER_IMAGE="nanvix/toolchain:v$${MAJOR_MINOR}.x-minimal"; \
+		DOCKER_IMAGE="ghcr.io/nanvix/toolchain-gcc:latest"; \
 	else \
-		DOCKER_IMAGE="nanvix/toolchain:latest-minimal"; \
+		DOCKER_IMAGE="ghcr.io/nanvix/toolchain-gcc:latest"; \
 	fi; \
 	echo "  Docker image: $$DOCKER_IMAGE"; \
 	TMPDIR=$$(mktemp -d); \


### PR DESCRIPTION
## Summary

Fix Docker image resolution in the init target of posix-tests Makefile.

### Changes
- Update Docker image from `nanvix/toolchain:v${MAJOR_MINOR}.x-minimal` to `ghcr.io/nanvix/toolchain-gcc:latest`

### Background
Docker images were migrated from Docker Hub to GitHub Container Registry. The old image naming scheme (`nanvix/toolchain:vX.Y.x-minimal`) no longer resolves.