### PR TITLE
ci: upgrade to nanvix-ci workflow v2.0.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,11 +30,13 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
+      docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
       platforms: '["microvm"]'
-      process-modes: '["multi-process","single-process","standalone"]'
+      memory-sizes: '["128mb"]'
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

- Bump reusable workflow from `v1.15.0` to `v2.0.0`
- Update `zutil-version` from `v0.7.48` to `v0.8.1`
- Pin `docker-image` to `ghcr.io/nanvix/toolchain-gcc` digest
- Replace `process-modes` with `memory-sizes` parameter
- Skip scheduled and `workflow_dispatch` events for CI job