### PR TITLE
build: migrate Docker image to ghcr.io/nanvix/toolchain-gcc

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -79,7 +79,7 @@ TESTABLE_SUITES = [
 ]
 
 # Docker image for cross-compilation.
-DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
+DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
 
 # Windows host-native binaries needed for test execution.
 WINDOWS_HOST_BINARIES = ["nanvixd.exe", "kernel.elf"]
@@ -419,11 +419,10 @@ class PosixTestsBuild(ZScript):
         log.success(f"Built {len(elfs)} test binaries in build/")
 
     def _resolve_docker_image(self) -> str:
-        """Resolve the Docker image tag from the Nanvix version.
+        """Resolve the Docker image tag for cross-compilation.
 
-        Derives the tag from the nanvix-version in nanvix.toml:
-        ``0.12.432`` → ``nanvix/toolchain:v0.12.x-minimal``.
-        Falls back to ``latest-minimal`` if the version is unavailable.
+        Returns the fixed GHCR toolchain-gcc image tag.
+        Falls back to the cached ``.docker-image`` file if present.
         """
         # Check for cached .docker-image (from 'make init').
         cached = self.repo_root / ".nanvix" / ".docker-image"
@@ -431,15 +430,6 @@ class PosixTestsBuild(ZScript):
             tag = cached.read_text().strip()
             if tag:
                 return tag
-
-        # Derive from nanvix-version in manifest.
-        version = getattr(self.manifest, "sysroot_ref", None)
-        if version:
-            ver = version.value.lstrip("v")
-            parts = ver.split(".")
-            if len(parts) >= 2:
-                major_minor = f"{parts[0]}.{parts[1]}"
-                return f"nanvix/toolchain:v{major_minor}.x-minimal"
 
         return DOCKER_IMAGE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   'make init' must be run first to download the Nanvix release into .nanvix/.
 
 # BASE_IMAGE is resolved by 'make init' and saved in .nanvix/.docker-image.
-ARG BASE_IMAGE=nanvix/toolchain:latest-minimal
+ARG BASE_IMAGE=ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 FROM ${BASE_IMAGE} AS builder
 
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -62,15 +62,7 @@ $(NANVIX_DIR)/lib/libposix.a:
 	fi; \
 	echo "  Release: $$TAG_NAME"; \
 	echo "  Asset: $$ASSET_NAME"; \
-	CARGO_TOML=$$(gh api "repos/$(NANVIX_REPO)/contents/Cargo.toml?ref=$$TAG_NAME" \
-		--jq '.content' 2>/dev/null | base64 -d) || true; \
-	CARGO_VERSION=$$(echo "$$CARGO_TOML" | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/') || true; \
-	if [ -n "$$CARGO_VERSION" ]; then \
-		MAJOR_MINOR="$${CARGO_VERSION%.*}"; \
-		DOCKER_IMAGE="nanvix/toolchain:v$${MAJOR_MINOR}.x-minimal"; \
-	else \
-		DOCKER_IMAGE="nanvix/toolchain:latest-minimal"; \
-	fi; \
+	DOCKER_IMAGE="ghcr.io/nanvix/toolchain-gcc:sha-34a3641"; \
 	echo "  Docker image: $$DOCKER_IMAGE"; \
 	TMPDIR=$$(mktemp -d); \
 	gh release download "$$TAG_NAME" --repo "$(NANVIX_REPO)" \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make run SUITE=file-c
 ### Cross-Compilation
 
 Test suites are cross-compiled using the `i686-nanvix-gcc` toolchain inside the
-[`nanvix/toolchain`](https://hub.docker.com/r/nanvix/toolchain) minimal Docker image.
+[`ghcr.io/nanvix/toolchain-gcc`](https://github.com/nanvix/toolchain-gcc/pkgs/container/toolchain-gcc) Docker image.
 
 Each test suite is linked against:
 


### PR DESCRIPTION
## Summary

Migrate all Docker image references from the legacy `nanvix/toolchain:latest-minimal` (Docker Hub) to `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` (GitHub Container Registry).

## Changes

- **Dockerfile**: Updated `ARG BASE_IMAGE` default
- **Makefile**: Simplified `init` target — replaced dynamic Cargo.toml version derivation with fixed GHCR tag
- **.nanvix/z.py**: Updated `DOCKER_IMAGE` constant and simplified `_resolve_docker_image()`
- **README.md**: Updated documentation link to GHCR package

Resolves #98