### PR TITLE
fix: select release asset by (platform, mode, memory) and pass -bin-dir to nanvixd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ NANVIX_REPO ?= nanvix/nanvix
 # Nanvix release directory (populated by 'make init').
 NANVIX_DIR ?= .nanvix
 
+# Build/runtime knobs (must match Dockerfile defaults). Used both to select the
+# correct release asset in 'make init' and to parameterize the Docker build.
+PLATFORM     ?= microvm
+PROCESS_MODE ?= multi-process
+MEMORY_SIZE  ?= 128mb
+
 # Test suites to build.
 SUITES := c-bindings dlfcn-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
@@ -27,12 +33,15 @@ all: $(addprefix build/,$(BINARIES))
 build/%.elf: src/ Makefile Dockerfile $(NANVIX_DIR)/lib/libposix.a
 	DOCKER_BUILDKIT=1 docker build \
 		--build-arg BASE_IMAGE=$$(cat $(NANVIX_DIR)/.docker-image) \
+		--build-arg PLATFORM=$(PLATFORM) \
+		--build-arg PROCESS_MODE=$(PROCESS_MODE) \
+		--build-arg MEMORY_SIZE=$(MEMORY_SIZE) \
 		--output type=local,dest=build .
 	@touch $(addprefix build/,$(BINARIES))
 
 # Run a specific test suite on Nanvix.
 run: build/$(SUITE).elf
-	$(NANVIX_DIR)/bin/nanvixd.elf -console-file /dev/stdout -- ./build/$(SUITE).elf
+	$(NANVIX_DIR)/bin/nanvixd.elf -bin-dir $(NANVIX_DIR)/bin -console-file /dev/stdout -- ./build/$(SUITE).elf
 
 clean:
 	rm -rf build
@@ -54,10 +63,16 @@ $(NANVIX_DIR)/lib/libposix.a:
 	@echo "Downloading the latest Nanvix release..."
 	@RELEASE_INFO=$$(gh release view --repo "$(NANVIX_REPO)" --json tagName,assets); \
 	TAG_NAME=$$(echo "$$RELEASE_INFO" | jq -r '.tagName'); \
-	ASSET_NAME=$$(echo "$$RELEASE_INFO" | jq -r \
-		'.assets[] | select(.name | startswith("nanvix-x86-microvm-multi-process-release")) | .name'); \
+	ASSET_PREFIX="nanvix-x86-$(PLATFORM)-$(PROCESS_MODE)-release-$(MEMORY_SIZE)-"; \
+	ASSET_NAME=$$(echo "$$RELEASE_INFO" | jq -r --arg prefix "$$ASSET_PREFIX" \
+		'.assets[] | select(.name | startswith($$prefix)) | .name'); \
 	if [ -z "$$ASSET_NAME" ]; then \
-		echo "ERROR: Could not find a microvm multi-process release asset." >&2; \
+		echo "ERROR: Could not find a release asset starting with '$$ASSET_PREFIX'." >&2; \
+		exit 1; \
+	fi; \
+	if [ "$$(echo "$$ASSET_NAME" | wc -l)" -ne 1 ]; then \
+		echo "ERROR: Multiple release assets matched '$$ASSET_PREFIX':" >&2; \
+		echo "$$ASSET_NAME" >&2; \
 		exit 1; \
 	fi; \
 	echo "  Release: $$TAG_NAME"; \


### PR DESCRIPTION
## Problem

`make init` was broken: the jq selector

```
.assets[] | select(.name | startswith("nanvix-x86-microvm-multi-process-release")) | .name
```

now matches **two** assets in v0.13.11 (`...-128mb-...` and `...-256mb-...`). The two names get concatenated with a newline into `$ASSET_NAME`, which then breaks `gh release download --pattern` (no match) and `tar` (`Cannot open` with the literal `\n` in the path). Init silently leaves `.nanvix/` empty, so the subsequent Docker build fails with:

```
ld: cannot open linker script file /workspace/.nanvix/lib/user.ld: No such file or directory
```

Separately, `make run SUITE=…` failed with:

```
Error: required binaries not available locally: kernel.elf, linuxd.elf, uservm.elf
```

because the recipe didn't pass `-bin-dir` to `nanvixd` (multi-process mode needs it to locate its sidecars; `./z` already does this).

## Fix

* Surface `PLATFORM`, `PROCESS_MODE`, `MEMORY_SIZE` as Makefile variables with the same defaults as the Dockerfile (`microvm` / `multi-process` / `128mb`).
* Tighten the asset selector to `nanvix-x86-$(PLATFORM)-$(PROCESS_MODE)-release-$(MEMORY_SIZE)-` (passed safely via `jq --arg`), and fail loudly if zero or more than one assets still match.
* Forward the same vars to `docker build` via `--build-arg` so init and build stay in sync.
* Add `-bin-dir $(NANVIX_DIR)/bin` to the `run` recipe.

## Verification

```
make distclean && make           # 14 ELFs built
for s in <9 testable suites>; do make run SUITE=$s; done   # all rc=0
make distclean && ./z setup --with-docker=… && ./z build && ./z test
# smoke 14/14 OK, integration 9/9 OK, *** POSIX tests PASSED ***
```

The `./z test` integration failures (exit 255 on 9 suites) reported in the original bug also disappear after a clean cycle — they were a downstream effect of the same multi-asset bug poisoning the sysroot, not a separate defect.