### PR TITLE
fix: consolidate the sysroot layout and drop NANVIX_SYSROOT

### DIFF
--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.docker-image
 venv/
 cache/
 sysroot/

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -28,7 +28,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
 
 # ---------------------------------------------------------------------------
 # Platform detection
@@ -161,12 +161,8 @@ class PosixTestsBuild(ZScript):
             self.config.set(_CFG_LOCAL_NANVIX, nanvix_path)
             self.config.save()
 
-        sysroot = self.config.get(CFG_SYSROOT, "")
-        if not sysroot:
-            return
-
         nanvix_dir = Path(nanvix_path)
-        sysroot_path = Path(sysroot)
+        sysroot_path = self.nanvix_dir / "sysroot"
 
         log.info(f"Overlaying local Nanvix binaries from {nanvix_dir}")
 
@@ -219,15 +215,8 @@ class PosixTestsBuild(ZScript):
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
-        sysroot = self.config.get(CFG_SYSROOT, "")
-        if not sysroot:
-            log.fatal(
-                f"{CFG_SYSROOT} is not set.",
-                code=EXIT_MISSING_DEP,
-                hint="Run `./z setup` first to download the sysroot.",
-            )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
-        sysroot_p = self.translate_path(Path(sysroot))
+        sysroot_p = self.translate_path(self.nanvix_dir / "sysroot")
         toolchain_p = self.translate_path(Path(toolchain))
 
         args = [
@@ -312,7 +301,6 @@ class PosixTestsBuild(ZScript):
 
             self.sysroot = Sysroot(sysroot_dir.resolve())
             self.sysroot.verify(self.sysroot_required_files())
-            self.config.set(CFG_SYSROOT, str(self.sysroot.path))
             self.config.set(_CFG_LOCAL_NANVIX, local_nanvix)
             self.config.save()
             used_fallback = False
@@ -382,13 +370,7 @@ class PosixTestsBuild(ZScript):
         build_dir = self.repo_root / "build"
         build_dir.mkdir(exist_ok=True)
 
-        # Determine the sysroot path relative to the repo root.
-        # nanvix-zutil places files in .nanvix/sysroot/; the old 'make init'
-        # places them directly in .nanvix/.  Pass the correct path so the
-        # Dockerfile can forward it to Make.
         sysroot_rel = ".nanvix/sysroot"
-        if not (self.repo_root / sysroot_rel / "lib" / "libposix.a").is_file():
-            sysroot_rel = ".nanvix"
 
         log.info(f"Building via Docker ({docker_image})...")
         subprocess.run(
@@ -437,15 +419,9 @@ class PosixTestsBuild(ZScript):
 
     def _run_tests_native(self) -> None:
         """Run test binaries from ``build/`` using ``nanvixd``."""
-        sysroot = self.config.get(CFG_SYSROOT, "")
-        if not sysroot:
-            log.fatal(
-                f"{CFG_SYSROOT} is not set.",
-                code=EXIT_MISSING_DEP,
-                hint="Run `./z setup` first.",
-            )
+        sysroot = self.nanvix_dir / "sysroot"
         nanvixd_name = "nanvixd.exe" if IS_WINDOWS else "nanvixd.elf"
-        nanvixd = Path(sysroot) / "bin" / nanvixd_name
+        nanvixd = sysroot / "bin" / nanvixd_name
         if not nanvixd.is_file():
             log.fatal(
                 f"{nanvixd_name} not found in sysroot.",
@@ -466,7 +442,7 @@ class PosixTestsBuild(ZScript):
         # --- Integration tests ---
         print("Running integration tests...")
         failed: list[str] = []
-        bin_dir = str((Path(sysroot) / "bin").resolve())
+        bin_dir = str((sysroot / "bin").resolve())
         for suite in TESTABLE_SUITES:
             binary = build_dir / f"{suite}.elf"
             if not binary.is_file():
@@ -508,7 +484,7 @@ class PosixTestsBuild(ZScript):
         """
         from nanvix_zutil import CFG_GH_TOKEN
 
-        sysroot_path = Path(self.config.get(CFG_SYSROOT) or "")
+        sysroot_path = self.nanvix_dir / "sysroot"
         bin_dir = sysroot_path / "bin"
 
         # Skip if already present.

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -41,7 +41,6 @@ IS_WINDOWS = sys.platform == "win32"
 # ---------------------------------------------------------------------------
 
 # Makefile variable names (build-system-specific).
-_MAKE_VAR_SYSROOT = "NANVIX_SYSROOT"
 _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
 _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
@@ -216,14 +215,12 @@ class PosixTestsBuild(ZScript):
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
-        sysroot_p = self.translate_path(self.nanvix_dir / "sysroot")
         toolchain_p = self.translate_path(Path(toolchain))
 
         args = [
             "make",
             "-C",
             "src",
-            f"{_MAKE_VAR_SYSROOT}={sysroot_p}",
             f"{_MAKE_VAR_TOOLCHAIN}={toolchain_p}",
             f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
             f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
@@ -370,8 +367,6 @@ class PosixTestsBuild(ZScript):
         build_dir = self.repo_root / "build"
         build_dir.mkdir(exist_ok=True)
 
-        sysroot_rel = ".nanvix/sysroot"
-
         log.info(f"Building via Docker ({docker_image})...")
         subprocess.run(
             [
@@ -379,8 +374,6 @@ class PosixTestsBuild(ZScript):
                 "build",
                 "--build-arg",
                 f"BASE_IMAGE={docker_image}",
-                "--build-arg",
-                f"NANVIX_SYSROOT={sysroot_rel}",
                 "--build-arg",
                 f"PLATFORM={self.config.machine}",
                 "--build-arg",

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #       --output type=local,dest=build .
 #
 # Prerequisites:
-#   'make init' must be run first to download the Nanvix release into .nanvix/.
+#   'make init' must be run first to download the Nanvix release into .nanvix/sysroot/.
 
 # BASE_IMAGE is resolved by 'make init' and saved in .nanvix/.docker-image.
 ARG BASE_IMAGE=ghcr.io/nanvix/toolchain-gcc:sha-34a3641
@@ -23,14 +23,12 @@ COPY Makefile ./
 COPY .nanvix/ .nanvix/
 
 # Build configuration — forwarded from z.py or overridden via --build-arg.
-ARG NANVIX_SYSROOT=.nanvix
+ARG NANVIX_SYSROOT=.nanvix/sysroot
 ARG PLATFORM=microvm
 ARG PROCESS_MODE=multi-process
 ARG MEMORY_SIZE=128mb
 
 # Build all test suites.
-# NANVIX_SYSROOT is set so the build works whether the sysroot lives at
-# .nanvix/ (make init layout) or .nanvix/sysroot/ (nanvix-zutil layout).
 RUN mkdir -p build && make compile \
     NANVIX_SYSROOT=/workspace/${NANVIX_SYSROOT} \
     PLATFORM=${PLATFORM} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,12 @@ COPY Makefile ./
 COPY .nanvix/ .nanvix/
 
 # Build configuration — forwarded from z.py or overridden via --build-arg.
-ARG NANVIX_SYSROOT=.nanvix/sysroot
 ARG PLATFORM=microvm
 ARG PROCESS_MODE=multi-process
 ARG MEMORY_SIZE=128mb
 
 # Build all test suites.
 RUN mkdir -p build && make compile \
-    NANVIX_SYSROOT=/workspace/${NANVIX_SYSROOT} \
     PLATFORM=${PLATFORM} \
     PROCESS_MODE=${PROCESS_MODE} \
     MEMORY_SIZE=${MEMORY_SIZE}

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,15 @@ BINARIES := $(addsuffix .elf,$(SUITES))
 all: $(addprefix build/,$(BINARIES))
 
 # Build all test suite ELFs inside Docker and export to build/.
-build/%.elf: src/ Makefile Dockerfile $(NANVIX_DIR)/lib/libposix.a
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BASE_IMAGE=$$(cat $(NANVIX_DIR)/.docker-image) \
+# BASE_IMAGE is read from the .docker-image cache if present (written by
+# `make init`); otherwise the Dockerfile's default BASE_IMAGE is used.
+build/%.elf: src/ Makefile Dockerfile $(NANVIX_DIR)/sysroot/lib/libposix.a
+	@BASE_IMAGE_ARG=""; \
+	if [ -f $(NANVIX_DIR)/.docker-image ]; then \
+		BASE_IMAGE_ARG="--build-arg BASE_IMAGE=$$(cat $(NANVIX_DIR)/.docker-image)"; \
+	fi; \
+	set -x; \
+	DOCKER_BUILDKIT=1 docker build $$BASE_IMAGE_ARG \
 		--build-arg PLATFORM=$(PLATFORM) \
 		--build-arg PROCESS_MODE=$(PROCESS_MODE) \
 		--build-arg MEMORY_SIZE=$(MEMORY_SIZE) \
@@ -41,7 +47,7 @@ build/%.elf: src/ Makefile Dockerfile $(NANVIX_DIR)/lib/libposix.a
 
 # Run a specific test suite on Nanvix.
 run: build/$(SUITE).elf
-	$(NANVIX_DIR)/bin/nanvixd.elf -bin-dir $(NANVIX_DIR)/bin -console-file /dev/stdout -- ./build/$(SUITE).elf
+	$(NANVIX_DIR)/sysroot/bin/nanvixd.elf -bin-dir $(NANVIX_DIR)/sysroot/bin -console-file /dev/stdout -- ./build/$(SUITE).elf
 
 clean:
 	rm -rf build
@@ -57,9 +63,9 @@ compile:
 # Init — download the latest Nanvix release and resolve the Docker image tag
 #===============================================================================
 
-init: $(NANVIX_DIR)/lib/libposix.a
+init: $(NANVIX_DIR)/sysroot/lib/libposix.a
 
-$(NANVIX_DIR)/lib/libposix.a:
+$(NANVIX_DIR)/sysroot/lib/libposix.a:
 	@echo "Downloading the latest Nanvix release..."
 	@RELEASE_INFO=$$(gh release view --repo "$(NANVIX_REPO)" --json tagName,assets); \
 	TAG_NAME=$$(echo "$$RELEASE_INFO" | jq -r '.tagName'); \
@@ -83,16 +89,15 @@ $(NANVIX_DIR)/lib/libposix.a:
 	gh release download "$$TAG_NAME" --repo "$(NANVIX_REPO)" \
 		--pattern "$$ASSET_NAME" \
 		--dir "$$TMPDIR"; \
-	mkdir -p $(NANVIX_DIR); \
-	tar xjf "$$TMPDIR/$$ASSET_NAME" -C $(NANVIX_DIR) --strip-components=1; \
+	mkdir -p $(NANVIX_DIR)/sysroot; \
+	tar xjf "$$TMPDIR/$$ASSET_NAME" -C $(NANVIX_DIR)/sysroot --strip-components=1; \
 	rm -rf "$$TMPDIR"; \
 	echo "$$DOCKER_IMAGE" > $(NANVIX_DIR)/.docker-image; \
 	echo ""; \
-	echo "Done. Nanvix release extracted to $(NANVIX_DIR)/."
+	echo "Done. Nanvix release extracted to $(NANVIX_DIR)/sysroot/."
 
 distclean: clean
 	rm -rf $(NANVIX_DIR)/sysroot $(NANVIX_DIR)/cache $(NANVIX_DIR)/buildroot
 	rm -rf $(NANVIX_DIR)/venv $(NANVIX_DIR)/env.json $(NANVIX_DIR)/.docker-image
-	rm -rf $(NANVIX_DIR)/lib $(NANVIX_DIR)/bin $(NANVIX_DIR)/include
 
 .PHONY: all run compile clean init distclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@
 #===============================================================================
 
 # Nanvix sysroot (set by the host Makefile or z.py).
-NANVIX_SYSROOT ?= ../.nanvix
+NANVIX_SYSROOT ?= ../.nanvix/sysroot
 
 # Toolchain directory (set by the Docker image).
 NANVIX_TOOLCHAIN ?= /opt/nanvix

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,9 @@
 # Build Configuration
 #===============================================================================
 
-# Nanvix sysroot (set by the host Makefile or z.py).
-NANVIX_SYSROOT ?= ../.nanvix/sysroot
+# Nanvix sysroot. Always at .nanvix/sysroot/ relative to the repo root.
+# Resolved to an absolute path because per-suite makes run from src/<suite>/.
+SYSROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../.nanvix/sysroot)
 
 # Toolchain directory (set by the Docker image).
 NANVIX_TOOLCHAIN ?= /opt/nanvix
@@ -46,10 +47,10 @@ CXXFLAGS += -D__NANVIX_STANDALONE__
 endif
 
 # Linker flags.
-export LDFLAGS := -z noexecstack -T $(NANVIX_SYSROOT)/lib/user.ld
+export LDFLAGS := -z noexecstack -T $(SYSROOT)/lib/user.ld
 
 # Libraries.
-export LIBPOSIX := $(NANVIX_SYSROOT)/lib/libposix.a
+export LIBPOSIX := $(SYSROOT)/lib/libposix.a
 export LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
 export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export LIBCXX := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libstdc++.a
@@ -122,7 +123,7 @@ else
 			continue; \
 		fi; \
 		echo "RUN  $$suite..."; \
-		$(NANVIX_SYSROOT)/bin/nanvixd.elf -console-file /dev/stdout -- "$$binary" && echo "OK   $$suite" || { echo "FAIL $$suite"; exit 1; }; \
+		$(SYSROOT)/bin/nanvixd.elf -bin-dir $(SYSROOT)/bin -console-file /dev/stdout -- "$$binary" && echo "OK   $$suite" || { echo "FAIL $$suite"; exit 1; }; \
 	done
 endif
 


### PR DESCRIPTION
Stacked on #119. Closes #120.

## Consolidate the sysroot layout and drop `NANVIX_SYSROOT`

The Nanvix sysroot now lives at a single fixed location,
`.nanvix/sysroot/`, populated identically by `make init` and
`./z setup`. The `NANVIX_SYSROOT` knob that was previously plumbed
through `z.py` → `Dockerfile` → `src/Makefile` to paper over two
different layouts is gone.

### Changes

- **`Makefile`**: `make init` extracts the release tarball into
  `.nanvix/sysroot/`. `run` and the build rule reference
  `$(NANVIX_DIR)/sysroot/...` (including `-bin-dir`). `distclean`
  no longer wipes the legacy `.nanvix/{lib,bin,include}` paths.
- **`Dockerfile`**: no `NANVIX_SYSROOT` `ARG` and no forwarding into
  `make compile`.
- **`src/Makefile`**: uses a private `SYSROOT` variable, computed as
  `$(abspath $(dir $(lastword $(MAKEFILE_LIST)))../.nanvix/sysroot)`
  so it resolves correctly from the per-suite `src/<suite>/` cwd.
- **`.nanvix/z.py`**: derives the sysroot path from `self.nanvix_dir`,
  no longer reads or writes `CFG_SYSROOT`, and no longer passes
  `NANVIX_SYSROOT` to `make` or `docker build`.
- **`.nanvix/.gitignore`**: ignores the cached `.docker-image` file
  written by `make init`.

### Verification

- `make all` — builds 14/14 ELFs via Docker.
- `make run SUITE=hello-c` — boots and prints `Hello, world from C!`.
- `./z test` — all smoke tests pass; all 9 integration suites pass
  (`*** POSIX tests PASSED ***`).

### Notes

- `CFG_SYSROOT` is no longer read here; if other repos still set it,
  it's silently ignored.
