### PR TITLE
fix(ci): bump nanvix/workflows to v2.0.1 and grant packages: read

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,6 +23,7 @@ permissions:
   actions: write
   issues: write
   pull-requests: write
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
       zutil-version: "v0.8.2"
       docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length


### PR DESCRIPTION
Stacks two commits, intended to supersede the open `automation/update-nanvix-workflows` PR:

1. `[ci] E: Update nanvix workflow refs to v2.0.1` — identical to the automation commit.
2. `fix(ci): grant packages: read for v2.0.1 reusable workflow` — the missing permission grant.

## Why both in one PR

The bump alone fails immediately with `startup_failure` (zero jobs) because `nanvix/workflows` v2.0.1 added `packages: read` to its top-level reusable-workflow permissions ([commit 48eeaf7](https://github.com/nanvix/workflows/commit/48eeaf7)), and GitHub Actions enforces that a reusable workflow's effective permissions cannot exceed the caller job's. Our caller's explicit `permissions:` block omits `packages`, so it implicitly defaults to `none`.

This PR cannot be split: applying just the permission grant on default would un-block the automation PR, but pushing to the `automation/**` branch is blocked by repository ruleset (only the automation token bypasses).

## Cleanups included

Drops the redundant job-level `permissions:` block on `ci-scheduled` — it duplicated the workflow-level block exactly and added nothing besides maintenance burden.

## After merge

- Close the open `automation/update-nanvix-workflows` PR (will become a no-op).
- Future scheduled `Update Workflow Refs` runs will see default already at `@v2.0.1` and report `already up to date`.
