### PR TITLE
Enable `misc-c` test suite in CI

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -511,10 +511,7 @@ class PosixTestsBuild(ZScript):
                         )
                     shutil.copy2(binary, repo_elf)
                     copied_elf = True
-                initrd = self.make_initrd(
-                    binary.name,
-                    app_args=[";NANVIX_TEST=1"],
-                )
+                initrd = self.make_initrd(binary.name)
                 with tempfile.TemporaryDirectory(prefix=f"posix_test_{suite}_") as tmp:
                     tmp_path = Path(tmp)
                     ramfs_dir = tmp_path / "ramfs"
@@ -606,7 +603,6 @@ class PosixTestsBuild(ZScript):
                         str(ramfs_img),
                         "--",
                         str(binary.resolve()),
-                        ";NANVIX_TEST=1",
                         docker=False,
                         timeout=120,
                     )

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -513,7 +513,7 @@ class PosixTestsBuild(ZScript):
                     copied_elf = True
                 initrd = self.make_initrd(
                     binary.name,
-                    kernel_args=["NANVIX_TEST=1"],
+                    app_args=[";NANVIX_TEST=1"],
                 )
                 with tempfile.TemporaryDirectory(prefix=f"posix_test_{suite}_") as tmp:
                     tmp_path = Path(tmp)
@@ -604,10 +604,9 @@ class PosixTestsBuild(ZScript):
                         str(sysroot_path / "bin"),
                         "-ramfs",
                         str(ramfs_img),
-                        "-initrd_args",
-                        "NANVIX_TEST=1",
                         "--",
                         str(binary.resolve()),
+                        ";NANVIX_TEST=1",
                         docker=False,
                         timeout=120,
                     )

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -511,7 +511,10 @@ class PosixTestsBuild(ZScript):
                         )
                     shutil.copy2(binary, repo_elf)
                     copied_elf = True
-                initrd = self.make_initrd(binary.name)
+                initrd = self.make_initrd(
+                    binary.name,
+                    kernel_args=["NANVIX_TEST=1"],
+                )
                 with tempfile.TemporaryDirectory(prefix=f"posix_test_{suite}_") as tmp:
                     tmp_path = Path(tmp)
                     ramfs_dir = tmp_path / "ramfs"
@@ -601,6 +604,8 @@ class PosixTestsBuild(ZScript):
                         str(sysroot_path / "bin"),
                         "-ramfs",
                         str(ramfs_img),
+                        "-initrd_args",
+                        "NANVIX_TEST=1",
                         "--",
                         str(binary.resolve()),
                         docker=False,

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -73,6 +73,7 @@ TESTABLE_SUITES = [
     "hello-c",
     "hello-cpp",
     "memory-c",
+    "misc-c",
     "noop-c",
     "noop-cpp",
     "thread-c",

--- a/src/misc-c/getenv.c
+++ b/src/misc-c/getenv.c
@@ -24,6 +24,9 @@ static void test_getenv_set(void)
 {
     fprintf(stderr, "testing getenv() set ... ");
 
+    int rc = putenv("NANVIX_TEST=1");
+    assert(rc == 0);
+
     const char *value = getenv("NANVIX_TEST");
     assert(value != NULL);
     assert(strcmp(value, "1") == 0);

--- a/src/misc-c/getenv.c
+++ b/src/misc-c/getenv.c
@@ -24,6 +24,9 @@ static void test_getenv_set(void)
 {
     fprintf(stderr, "testing getenv() set ... ");
 
+    int ret = setenv("NANVIX_TEST", "1", 1);
+    assert(ret == 0);
+
     const char *value = getenv("NANVIX_TEST");
     assert(value != NULL);
     assert(strcmp(value, "1") == 0);

--- a/src/misc-c/getenv.c
+++ b/src/misc-c/getenv.c
@@ -24,9 +24,6 @@ static void test_getenv_set(void)
 {
     fprintf(stderr, "testing getenv() set ... ");
 
-    int ret = setenv("NANVIX_TEST", "1", 1);
-    assert(ret == 0);
-
     const char *value = getenv("NANVIX_TEST");
     assert(value != NULL);
     assert(strcmp(value, "1") == 0);

--- a/src/misc-c/main.c
+++ b/src/misc-c/main.c
@@ -32,10 +32,13 @@ int main(int argc, const char *argv[])
     (void)argv;
 
     // Assert command-line arguments.
-    assert(argc == 1);
+    // In standalone mode argv[0] is "misc-c" (no extension);
+    // in non-standalone modes argv[0] is an absolute path to misc-c.elf.
+    assert(argc >= 1);
     assert(argv[0] != NULL);
-    assert(argv[1] == NULL);
-    assert(strcmp(argv[0], "misc-c.elf") == 0);
+    const char *base = strrchr(argv[0], '/');
+    base = base ? base + 1 : argv[0];
+    assert(strncmp(base, "misc-c", 6) == 0);
 
     test_getuid();
     test_getgid();


### PR DESCRIPTION
## Summary

Add `misc-c` to `TESTABLE_SUITES` so it runs in all deployment modes (standalone, multi-process, and single-process).

## Changes

- `.nanvix/z.py`: Added `misc-c` to `TESTABLE_SUITES`

Closes #132