### PR TITLE
Enable `dlfcn-c` test suite in standalone mode

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -80,6 +80,17 @@ TESTABLE_SUITES = [
     "thread-c",
 ]
 
+# Suites that require ramfs-bundled shared libraries and only run in standalone mode.
+STANDALONE_ONLY_SUITES = [
+    "dlfcn-c",
+]
+
+# Shared libraries that must be bundled into the ramfs for specific suites.
+# Maps suite name to a list of (source_filename_in_build_dir, ramfs_target_path).
+SUITE_RAMFS_LIBS: dict[str, list[tuple[str, str]]] = {
+    "dlfcn-c": [("libmul.so", "lib/libmul.so")],
+}
+
 # Docker image for cross-compilation.
 DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
 
@@ -495,7 +506,7 @@ class PosixTestsBuild(ZScript):
         make_initrd resolves binary paths relative to it.
         """
         failed: list[str] = []
-        for suite in TESTABLE_SUITES:
+        for suite in TESTABLE_SUITES + STANDALONE_ONLY_SUITES:
             binary = build_dir / f"{suite}.elf"
             if not binary.is_file():
                 print(f"SKIP {suite}")
@@ -518,6 +529,22 @@ class PosixTestsBuild(ZScript):
                     ramfs_dir = tmp_path / "ramfs"
                     ramfs_dir.mkdir()
                     (ramfs_dir / "tmp").mkdir()
+
+                    # Bundle shared libraries required by this suite.
+                    libs_missing = False
+                    for src_name, ramfs_path in SUITE_RAMFS_LIBS.get(suite, []):
+                        src_lib = build_dir / src_name
+                        if not src_lib.is_file():
+                            print(f"FAIL {suite}: missing shared library {src_lib}")
+                            failed.append(suite)
+                            libs_missing = True
+                            break
+                        dst_lib = ramfs_dir / ramfs_path
+                        dst_lib.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(src_lib, dst_lib)
+                    if libs_missing:
+                        continue
+
                     ramfs_img = tmp_path / "rootfs.img"
 
                     self.run(

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir -p build && make compile \
     PROCESS_MODE=${PROCESS_MODE} \
     MEMORY_SIZE=${MEMORY_SIZE}
 
-# Export the compiled binaries.
+# Export the compiled binaries and shared libraries.
 FROM scratch
 COPY --from=builder /workspace/build/*.elf /
+COPY --from=builder /workspace/build/*.so /


### PR DESCRIPTION
## Summary

Add infrastructure to bundle shared libraries into the ramfs image for standalone test execution. This is the groundwork for enabling the `dlfcn-c` test suite in CI (#133).

## Changes

- Add `SUITE_RAMFS_LIBS` mapping that declares per-suite shared library dependencies as `(build_dir_filename, ramfs_target_path)` pairs
- In `_run_tests_standalone()`, copy declared libraries into the ramfs directory before building the ramfs image
- Register `dlfcn-c`'s dependency on `libmul.so` at `lib/libmul.so`

## Notes

`dlfcn-c` is **not yet added** to `TESTABLE_SUITES` — the ramfs bundling approach is only valid for standalone builds and a non-standalone strategy is still needed.

## Testing

- All existing test suites pass (`./z test`)
- `dlfcn-c` was manually verified to pass in standalone mode with the ramfs bundling

Closes #133