### PR TITLE
Enable `dlfcn-pie-c` test suite in CI

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -83,12 +83,14 @@ TESTABLE_SUITES = [
 # Suites that require ramfs-bundled shared libraries and only run in standalone mode.
 STANDALONE_ONLY_SUITES = [
     "dlfcn-c",
+    "dlfcn-pie-c",
 ]
 
 # Shared libraries that must be bundled into the ramfs for specific suites.
 # Maps suite name to a list of (source_filename_in_build_dir, ramfs_target_path).
 SUITE_RAMFS_LIBS: dict[str, list[tuple[str, str]]] = {
     "dlfcn-c": [("libmul.so", "lib/libmul.so")],
+    "dlfcn-pie-c": [("libmul-pie.so", "lib/libmul-pie.so")],
 }
 
 # Docker image for cross-compilation.


### PR DESCRIPTION
## Summary

Enable the `dlfcn-pie-c` test suite in CI. The suite tests POSIX dynamic linking interfaces (`dlopen`/`dlsym`/`dlclose`) under position-independent executables (PIE).

## Changes

- Add `dlfcn-pie-c` to `STANDALONE_ONLY_SUITES` so it runs during standalone-mode integration tests
- Register `libmul-pie.so` in `SUITE_RAMFS_LIBS` so the shared library is bundled into the ramfs image at `lib/libmul-pie.so`, matching the path expected by the test's `dlopen()` call

Closes #129