### PR TITLE
Enable network-c test suite in CI

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -76,6 +76,7 @@ TESTABLE_SUITES = [
     "hello-cpp",
     "memory-c",
     "misc-c",
+    "network-c",
     "noop-c",
     "noop-cpp",
     "thread-c",
@@ -86,6 +87,11 @@ STANDALONE_ONLY_SUITES = [
     "dlfcn-c",
     "dlfcn-pie-c",
 ]
+
+# Suites that require host networking (passed as -allow-host-networking to nanvixd).
+SUITES_REQUIRING_NETWORKING: set[str] = {
+    "network-c",
+}
 
 # Shared libraries that must be bundled into the ramfs for specific suites.
 # Maps suite name to a list of (source_filename_in_build_dir, ramfs_target_path).
@@ -570,9 +576,10 @@ class PosixTestsBuild(ZScript):
                         str(sysroot_path / "bin"),
                         "-ramfs",
                         str(ramfs_img),
-                        "--",
-                        str(initrd),
                     ]
+                    if suite in SUITES_REQUIRING_NETWORKING:
+                        cmd.append("-allow-host-networking")
+                    cmd.extend(["--", str(initrd)])
                     log.info(f"$ {' '.join(cmd)}")
                     subprocess.run(
                         cmd,
@@ -648,9 +655,11 @@ class PosixTestsBuild(ZScript):
                         str(sysroot_path / "bin"),
                         "-ramfs",
                         str(ramfs_img),
-                        "--",
-                        str(binary.resolve()),
                     ]
+                    if suite in SUITES_REQUIRING_NETWORKING:
+                        cmd.append("-allow-host-networking")
+                    cmd.append("--")
+                    cmd.append(str(binary))
                     # nanvixd packs args and env vars into a separate
                     # positional argument after the binary path:
                     #   nanvixd ... -- <binary> "<args>;<env vars>"

--- a/src/network-c/main.c
+++ b/src/network-c/main.c
@@ -14,7 +14,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#ifndef __NANVIX_STANDALONE__
 #include <sys/un.h>
+#endif
 #include <time.h>
 #include <unistd.h>
 
@@ -121,6 +123,7 @@ int main(int argc, const char *argv[])
     );
     STATIC_ASSERT_SIZE(struct sockaddr_in, sizeof(struct sockaddr_storage));
 
+#ifndef __NANVIX_STANDALONE__
     // Sanity check size of `sockaddr_un` structure.
     STATIC_ASSERT_SIZE(struct sockaddr_un,
                        sizeof(unsigned char) +       // sun_len
@@ -128,19 +131,26 @@ int main(int argc, const char *argv[])
                            SUNPATHLEN * sizeof(char) // sun_path
     );
     STATIC_ASSERT_SIZE(struct sockaddr_un, sizeof(struct sockaddr_storage));
+#endif
 
     srand(SEED);
 
     in_port_t sin_port = htons(1992);
     struct in_addr sin_addr = {.s_addr = htonl(0x7f000001)};
-    char sun_path[UNIX_SOCKET_NAME_LEN];
-    for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
-        sun_path[i] = 'a' + (rand() % 26);
-    }
-    sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
 
     test_inet_sockets(sin_port, sin_addr);
-    test_unix_sockets(sun_path);
+
+    // Unix-domain sockets require linuxd; networkd only supports AF_INET sockets.
+#ifndef __NANVIX_STANDALONE__
+    {
+        char sun_path[UNIX_SOCKET_NAME_LEN];
+        for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
+            sun_path[i] = 'a' + (rand() % 26);
+        }
+        sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
+        test_unix_sockets(sun_path);
+    }
+#endif
 
     // Write magic string to signal that the test passed.
     {

--- a/src/network-c/unix.c
+++ b/src/network-c/unix.c
@@ -112,6 +112,9 @@ void test_unix_sockets(char sun_path[])
     strncpy(sockaddr.sun_path, sun_path, sizeof(sockaddr.sun_path) - 1);
     sockaddr.sun_path[sizeof(sockaddr.sun_path) - 1] = '\0';
 
+    // Clean up any leftover socket file from a previous run.
+    unlink(sun_path);
+
     test_create_socket(domain, type, protocol);
     test_bind_socket(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
     test_listen_socket(


### PR DESCRIPTION
## Summary

Enable the `network-c` test suite in CI by adding it to `TESTABLE_SUITES` and configuring the test runner to pass `-allow-host-networking` to nanvixd for suites that require host networking support.

## Problem

The `network-c` test suite was not being run in CI (issue #131). Additionally, in standalone mode, networkd only supports `AF_INET` sockets — UNIX domain sockets require linuxd, which is not available.

## Changes

- **`.nanvix/z.py`**: Add `network-c` to `TESTABLE_SUITES`; introduce `SUITES_REQUIRING_NETWORKING` set; inject `-allow-host-networking` flag into the nanvixd command line for networking suites in both standalone and non-standalone test runners.
- **`src/network-c/main.c`**: Wrap `<sys/un.h>` include, `sockaddr_un` static assertions, and `test_unix_sockets()` call with `#ifndef __NANVIX_STANDALONE__` guards. Scope `sun_path` into a block local to the guarded section.

## Testing

All test suites pass with `./z test`, including `network-c` (INET-only in standalone mode). Verified with back-to-back runs.

Closes #131