### PR TITLE
Enable CI job to run on manual workflow dispatch

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   ci:
-    if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'schedule'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
       zutil-version: "v0.9.1"


### PR DESCRIPTION
Previously, the `ci` job's condition excluded both `schedule` and `workflow_dispatch` events, which prevented the CI pipeline from running when triggered manually via GitHub's "Run workflow" button.

This change removes `workflow_dispatch` from the exclusion list so that manual dispatches now execute the CI job, allowing maintainers to re-run the full pipeline on demand without requiring a push or pull request.