### PR TITLE
Enable release bump from manual workflow dispatch

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -40,7 +40,7 @@ jobs:
       memory-sizes: '["128mb"]'
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
-      caller-event-name: ${{ github.event_name }}
+      caller-event-name: ${{ github.event_name == 'workflow_dispatch' && 'schedule' || github.event_name }}
       windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The reusable workflow's `update-nanvix-version` job only runs when `caller-event-name` is `schedule` or `repository_dispatch`. Previously, manual dispatch passed `workflow_dispatch` as the caller event name, which was not recognized — so no release bump occurred.

This PR maps `workflow_dispatch` to `schedule` so that manual triggers behave like scheduled runs, resolving the latest Nanvix release and opening a version-bump PR when the version has changed.