### PR TITLE
[ci] Sync zutils v0.10.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name != 'schedule'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
     with:
-      zutil-version: "v0.9.2"
+      zutil-version: "v0.10.0"
       docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
       platforms: '["microvm"]'
       memory-sizes: '["128mb"]'

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "posix-tests"
 version = "0.1.0"
-nanvix-version = "0.14.12"
+nanvix-version = "0.14.13"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -29,7 +29,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import CFG_SYSROOT, TOOLCHAIN_CONTAINER_PATH, EXIT_MISSING_DEP, ZScript, log
 
 # ---------------------------------------------------------------------------
 # Platform detection
@@ -268,9 +268,9 @@ class PosixTestsBuild(ZScript):
                 code=EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
-        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
+        toolchain = str(TOOLCHAIN_CONTAINER_PATH)
         sysroot_p = self.translate_path(Path(sysroot))
-        toolchain_p = self.translate_path(Path(toolchain))
+        toolchain_p = toolchain
 
         args = [
             "make",
@@ -288,7 +288,7 @@ class PosixTestsBuild(ZScript):
 
     def _has_native_toolchain(self) -> bool:
         """Check if the native cross-compilation toolchain is available."""
-        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix"
+        toolchain = str(TOOLCHAIN_CONTAINER_PATH)
         cc = Path(toolchain) / "bin" / "i686-nanvix-gcc"
         return cc.is_file()
 

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.9.2"
+    "0.10.0"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -41,15 +41,75 @@ catch {
     $null
 }
 
-function Bootstrap {
-    param([string]$Reason = "not found")
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   .\z.ps1 --with-zutils C:\src\zutils build
+#   .\z.ps1 --with-zutils=C:\src\zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutils = $null
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-zutils') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-zutils requires a path argument"
+        }
+        $withZutils = $ZArgs[$i + 1]
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
+        $withZutils = $Matches[1]
+        $i++
+    }
+    elseif ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
 
-    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+if ($withZutils) {
+    $resolved = Resolve-Path -LiteralPath $withZutils -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: --with-zutils path does not exist: $withZutils"
+    }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: --with-zutils is not a directory: $($resolved.Path)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $withZutils = $resolved.Path
+}
 
-    # Discover a Python 3 interpreter.
+function NewZutilVenv {
+    # Discover a Python 3 interpreter and (re)create the venv.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
         $venvArgs += "--clear"
@@ -71,15 +131,50 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
+}
+
+function Bootstrap {
+    param([string]$Reason = "not found")
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+    NewZutilVenv
     & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }
 }
 
+function BootstrapLocal {
+    # Install nanvix-zutil from $withZutils as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutils}..." -InformationAction Continue
+    NewZutilVenv
+    & $venvPython -m pip install --quiet -e "$($withZutils)[lint]"
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install (editable) failed (exit code $LASTEXITCODE)"
+    }
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutils') -Value $withZutils -NoNewline
+}
+
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+if ($withZutils) {
+    $zutilsMarker = Join-Path $venvDir '.with-zutils'
+    $recordedZutils = if (Test-Path -LiteralPath $zutilsMarker) {
+        (Get-Content -LiteralPath $zutilsMarker -Raw).Trim()
+    }
+    else { $null }
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutils -ne $withZutils)) {
+        BootstrapLocal
+    }
+    if (-not (Test-Path $venvZutil)) {
+        throw "BootstrapLocal completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+elseif ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
     if (-not (Test-Path $venvZutil)) {
         throw "Bootstrap completed but $venvZutil not found."
@@ -121,35 +216,6 @@ else {
             throw "Bootstrap completed but $venvZutil not found."
         }
         $bin = $venvZutil
-    }
-}
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-$filteredArgs = [System.Collections.Generic.List[string]]::new()
-$i = 0
-while ($i -lt $ZArgs.Count) {
-    if ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i++
-    }
-    else {
-        $filteredArgs.Add($ZArgs[$i])
-        $i++
     }
 }
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.9.2"
+PINNED_VERSION="0.10.0"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -27,6 +27,103 @@ function _resolve_venv_paths() {
 }
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
+
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
+# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   ./z.sh --with-zutils ~/src/zutils build
+#   ./z.sh --with-zutils=~/src/zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+#
+# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
+WITH_ZUTILS=""
+_resolve_zutils_path() {
+    local raw="$1"
+    if [ ! -e "$raw" ]; then
+        echo "ERROR: --with-zutils path does not exist: ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$raw" ]; then
+        echo "ERROR: --with-zutils is not a directory: ${raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTILS="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-zutils is not accessible (cd failed): ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTILS/pyproject.toml" ]; then
+        echo "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): ${WITH_ZUTILS}" >&2
+        exit 1
+    fi
+}
+
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-zutils=*)
+            _resolve_zutils_path "${1#--with-zutils=}"
+            shift
+            ;;
+        --with-zutils)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-zutils requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_zutils_path "$2"
+            shift 2
+            ;;
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+function bootstrap_local() {
+    # Install nanvix-zutil from $WITH_ZUTILS as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTILS}..." >&2
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTILS}[lint]"
+    printf '%s\n' "$WITH_ZUTILS" >"$VENV/.with-zutils"
+}
 
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
@@ -52,7 +149,16 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+if [ -n "$WITH_ZUTILS" ]; then
+    RECORDED_ZUTILS=""
+    if [ -f "$VENV/.with-zutils" ]; then
+        RECORDED_ZUTILS="$(cat "$VENV/.with-zutils")"
+    fi
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTILS" != "$WITH_ZUTILS" ]; then
+        bootstrap_local
+    fi
+    BIN="$VENV_BIN"
+elif [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
     bootstrap
     BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then
@@ -74,41 +180,6 @@ else
         BIN="$VENV_BIN"
     fi
 fi
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-# The nanvix-zutil CLI inspects positional args to find the subcommand;
-# --with-nanvix's PATH argument would be mistaken for a subcommand.
-# Pass the value via env var so z.py can pick it up.
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
-            shift 2
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
 
 # On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
 # so the Python distclean command cannot delete it.  Run without exec so the


### PR DESCRIPTION
Automated sync with [`v0.10.0`](https://github.com/nanvix/zutils/releases/tag/v0.10.0):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.14.13` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.