### PR TITLE
Only run docker in build

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -24,12 +24,19 @@ import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, TOOLCHAIN_CONTAINER_PATH, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import (
+    CFG_SYSROOT,
+    TOOLCHAIN_CONTAINER_PATH,
+    EXIT_MISSING_DEP,
+    ZScript,
+    log,
+)
 
 # ---------------------------------------------------------------------------
 # Platform detection
@@ -52,6 +59,8 @@ _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 ALL_SUITES = [
     "c-bindings",
     "dlfcn-c",
+    "dlfcn-global-c",
+    "dlfcn-needed-c",
     "dlfcn-pie-c",
     "echo-c",
     "echo-cpp",
@@ -392,7 +401,7 @@ class PosixTestsBuild(ZScript):
         if IS_WINDOWS or not self._has_native_toolchain():
             self._docker_build()
         else:
-            self.run(*self._make_args("all"), cwd=self.repo_root)
+            self.run(*self._make_args("all"), cwd=self.repo_root, docker=True)
 
     def test(self) -> None:
         """Run the POSIX test suites.
@@ -410,8 +419,42 @@ class PosixTestsBuild(ZScript):
             log.warning("Release packaging is not supported on Windows.")
             log.warning("Use a Linux host or CI to build release tarballs.")
             return
-        self.run(*self._make_args("package"), cwd=self.repo_root)
-        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
+
+        build_dir = self.repo_root / "build"
+        dist_dir = self.repo_root / "dist"
+        dist_dir.mkdir(parents=True, exist_ok=True)
+
+        artifact = (
+            f"posix-tests-{self.config.machine}-{self.config.deployment_mode}"
+            f"-{self.config.memory_size}.tar.gz"
+        )
+        tarball = dist_dir / artifact
+
+        log.info("Packaging release...")
+        missing = [s for s in ALL_SUITES if not (build_dir / f"{s}.elf").is_file()]
+        if missing:
+            log.fatal(
+                f"Missing test binaries: {', '.join(missing)}",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z build` first.",
+            )
+
+        with tarfile.open(tarball, "w:gz") as tf:
+            for suite in ALL_SUITES:
+                src = build_dir / f"{suite}.elf"
+                tf.add(src, arcname=f"{suite}.elf")
+        log.info(f"Package: {tarball}")
+
+        log.info("Verifying package...")
+        with tarfile.open(tarball, "r:gz") as tf:
+            names = set(tf.getnames())
+        for suite in ALL_SUITES:
+            if f"{suite}.elf" not in names:
+                log.fatal(
+                    f"Missing {suite}.elf in package",
+                    code=EXIT_MISSING_DEP,
+                )
+        log.success(f"Package verified: {tarball}")
 
     def clean(self) -> None:
         """Remove build artifacts."""
@@ -421,7 +464,7 @@ class PosixTestsBuild(ZScript):
                 shutil.rmtree(build_dir)
                 log.info("Removed build/")
         else:
-            self.run("make", "-C", "src", "clean", cwd=self.repo_root)
+            self.run("make", "-C", "src", "clean", cwd=self.repo_root, docker=False)
 
     # ---- Docker build ----------------------------------------------------
 


### PR DESCRIPTION
re: https://github.com/nanvix/zutils/issues/224

Same goal as nanvix/bzip2#242, nanvix/zlib#215, nanvix/libffi#210,
nanvix/openssl#226, nanvix/libxml2#51, nanvix/libxslt#52, nanvix/lxml#50:
Docker is invoked only during the `build` step.

### Shape (different from the others)

posix-tests has no `Makefile.nanvix`. `.nanvix/z.py` calls `make -C src`
for build/clean and runs nanvixd natively for tests. The top-level
`Makefile` (legacy `make init && make all` entry point) and the
`Dockerfile` are left untouched — they're a parallel host-side path
that's already docker-only-in-build compliant.

### `.nanvix/z.py`

- `build()` Linux+toolchain path: explicit `docker=True` (preserves
  prior default-True behavior).
- `clean()`: explicit `docker=False` (recipe is `rm -f` only).
- `release()`: rewritten from `make -C src package` + `verify-package`
  shell-outs to pure-Python `tarfile`. Mirrors the openssl / libxslt
  precedent. Necessary because `package: all` in `src/Makefile`
  triggers unconditional per-suite re-linking against
  `$(NANVIX_SYSROOT)/lib/user.ld` — when run natively with the
  container-translated sysroot path, the linker fails.
- `ALL_SUITES`: extended from 14 to 16 to match `src/Makefile`'s
  `SUITES` (adds `dlfcn-global-c`, `dlfcn-needed-c`). Pre-existing
  inconsistency surfaced by switching `release()` off `make`: the
  Python loop would otherwise drop two ELFs the old `make package`
  included. Also affects the smoke-test loop's coverage (positive
  side-effect).

Also folds in a black auto-reformat surfaced by `./z lint` after the
docker-isolation change. Same precedent as openssl / lxml.

### Verification

Ran the CI matrix locally (microvm × {multi-process, single-process,
standalone} × 128mb) against
`ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4ca…`:

- multi-process / single-process: setup + build + full test + release
  all PASSED. Docker observed only in the build step.
- standalone (limited test `-- test-smoke test-integration`): setup +
  build + release PASSED. The integration test reports 2 suite
  failures — `file-c` and `network-c`. **Pre-existing on `main`**:
  reproduced by checking out `main`'s `.nanvix/z.py` and re-running with
  the same env. Not caused by this change.
