### PR TITLE
ci: remove deprecated zutil-version parameter

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -32,9 +32,8 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.2
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
-      zutil-version: "v0.10.3"
       docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
       platforms: '["microvm"]'
       memory-sizes: '["128mb"]'


### PR DESCRIPTION
Bumps the `nanvix/workflows` reusable workflow pin from `v2.0.2` to `v2.1.0` and drops the now-removed `zutil-version` input. The pinned zutil version is read from the `.zutils-version` file at the repo root.

Upstream: nanvix/workflows#91 / https://github.com/nanvix/workflows/releases/tag/v2.1.0