### PR TITLE
[ci] E: Update nanvix workflow refs to v2.2.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.2.0
     with:
       docker-image: "ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3" # yamllint disable-line rule:line-length
       platforms: '["microvm"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.2.0`](https://github.com/nanvix/workflows/releases/tag/v2.2.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.