### PR TITLE
[dlfcn] E: Add tests for diamond DT_NEEDED graphs

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -66,6 +66,7 @@ _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 ALL_SUITES = [
     "c-bindings",
     "dlfcn-c",
+    "dlfcn-diamond-c",
     "dlfcn-global-c",
     "dlfcn-init-runpath-c",
     "dlfcn-needed-c",
@@ -102,6 +103,7 @@ TESTABLE_SUITES = [
 # Suites that require ramfs-bundled shared libraries and only run in standalone mode.
 STANDALONE_ONLY_SUITES = [
     "dlfcn-c",
+    "dlfcn-diamond-c",
     "dlfcn-init-runpath-c",
     "dlfcn-pie-c",
 ]
@@ -115,6 +117,12 @@ SUITES_REQUIRING_NETWORKING: set[str] = {
 # Maps suite name to a list of (source_filename_in_build_dir, ramfs_target_path).
 SUITE_RAMFS_LIBS: dict[str, list[tuple[str, str]]] = {
     "dlfcn-c": [("libmul.so", "lib/libmul.so")],
+    "dlfcn-diamond-c": [
+        ("libbase.so", "lib/libbase.so"),
+        ("libleft.so", "lib/libleft.so"),
+        ("libright.so", "lib/libright.so"),
+        ("libdiamond.so", "lib/libdiamond.so"),
+    ],
     "dlfcn-init-runpath-c": [
         ("libctor.so", "lib/libctor.so"),
         ("libparent.so", "lib/libparent.so"),

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PROCESS_MODE ?= multi-process
 MEMORY_SIZE  ?= 128mb
 
 # Test suites to build.
-SUITES := c-bindings dlfcn-c dlfcn-init-runpath-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
+SUITES := c-bindings dlfcn-c dlfcn-diamond-c dlfcn-init-runpath-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 # ELF binaries produced by each suite.
 BINARIES := $(addsuffix .elf,$(SUITES))

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,7 +65,7 @@ export LIBRARIES_DIR ?= $(BINARIES_DIR)
 # Test Suites
 #===============================================================================
 
-SUITES := c-bindings dlfcn-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
+SUITES := c-bindings dlfcn-c dlfcn-diamond-c dlfcn-global-c dlfcn-init-runpath-c dlfcn-needed-c dlfcn-pie-c echo-c echo-cpp file-c hello-c hello-cpp memory-c misc-c network-c noop-c noop-cpp thread-c
 
 #===============================================================================
 # Build Rules

--- a/src/dlfcn-diamond-c/Makefile
+++ b/src/dlfcn-diamond-c/Makefile
@@ -1,0 +1,76 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# dlfcn-diamond-c: Diamond DT_NEEDED graph resolution.
+#
+#   libdiamond.so
+#     +-- DT_NEEDED libleft.so   --+
+#     +-- DT_NEEDED libright.so  --+-- DT_NEEDED libbase.so
+#
+# The loader must consolidate the two DT_NEEDED libbase.so edges onto
+# a single in-memory libbase.so instance.
+
+PROGRAM_NAME := dlfcn-diamond-c
+
+SOURCES := $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+BINARY  := $(PROGRAM_NAME).elf
+
+all: $(OBJECTS) libs-all
+	$(CC) $(LDFLAGS) -pie -rdynamic -Wl,--no-dynamic-linker $(OBJECTS) $(LIBRARIES) -o $(BINARIES_DIR)/$(BINARY)
+
+clean: libs-clean
+	rm -f $(OBJECTS)
+	rm -f $(BINARIES_DIR)/$(BINARY)
+
+# libbase.so   - leaf of the diamond, no deps.
+# libleft.so   - DT_NEEDED libbase.so.
+# libright.so  - DT_NEEDED libbase.so.
+# libdiamond.so - DT_NEEDED libleft.so, libright.so.
+libs-all:
+	$(CC) libs/base.c -shared -fPIC -o $(LIBRARIES_DIR)/libbase.so
+	# `--enable-new-dtags` on the dependent libs ensures DT_RUNPATH (not
+	# the deprecated DT_RPATH) is emitted; the resolver in Nanvix's
+	# loader only honours DT_RUNPATH.  libbase.so has no DT_NEEDED so
+	# it does not need the flag.
+	$(CC) libs/left.c -shared -fPIC \
+	    -L$(LIBRARIES_DIR) -lbase \
+	    -Wl,--enable-new-dtags,-rpath,lib \
+	    -o $(LIBRARIES_DIR)/libleft.so
+	@if ! $(READELF) -d $(LIBRARIES_DIR)/libleft.so | grep -E -q '\(NEEDED\)[[:space:]]+Shared library: \[libbase\.so\]'; then \
+	echo "Error: DT_NEEDED libbase.so missing in $(LIBRARIES_DIR)/libleft.so"; \
+	$(READELF) -d $(LIBRARIES_DIR)/libleft.so; \
+	exit 1; \
+	fi
+	$(CC) libs/right.c -shared -fPIC \
+	    -L$(LIBRARIES_DIR) -lbase \
+	    -Wl,--enable-new-dtags,-rpath,lib \
+	    -o $(LIBRARIES_DIR)/libright.so
+	@if ! $(READELF) -d $(LIBRARIES_DIR)/libright.so | grep -E -q '\(NEEDED\)[[:space:]]+Shared library: \[libbase\.so\]'; then \
+	echo "Error: DT_NEEDED libbase.so missing in $(LIBRARIES_DIR)/libright.so"; \
+	$(READELF) -d $(LIBRARIES_DIR)/libright.so; \
+	exit 1; \
+	fi
+	$(CC) libs/diamond.c -shared -fPIC \
+	    -L$(LIBRARIES_DIR) -lleft -lright \
+	    -Wl,--enable-new-dtags,-rpath,lib \
+	    -o $(LIBRARIES_DIR)/libdiamond.so
+	@if ! $(READELF) -d $(LIBRARIES_DIR)/libdiamond.so | grep -E -q '\(NEEDED\)[[:space:]]+Shared library: \[libleft\.so\]'; then \
+	echo "Error: DT_NEEDED libleft.so missing in $(LIBRARIES_DIR)/libdiamond.so"; \
+	$(READELF) -d $(LIBRARIES_DIR)/libdiamond.so; \
+	exit 1; \
+	fi
+	@if ! $(READELF) -d $(LIBRARIES_DIR)/libdiamond.so | grep -E -q '\(NEEDED\)[[:space:]]+Shared library: \[libright\.so\]'; then \
+	echo "Error: DT_NEEDED libright.so missing in $(LIBRARIES_DIR)/libdiamond.so"; \
+	$(READELF) -d $(LIBRARIES_DIR)/libdiamond.so; \
+	exit 1; \
+	fi
+
+libs-clean:
+	rm -f $(LIBRARIES_DIR)/libbase.so
+	rm -f $(LIBRARIES_DIR)/libleft.so
+	rm -f $(LIBRARIES_DIR)/libright.so
+	rm -f $(LIBRARIES_DIR)/libdiamond.so
+
+%.o: %.c
+	$(CC) $(CFLAGS) -fPIE $< -c -o $@

--- a/src/dlfcn-diamond-c/libs/base.c
+++ b/src/dlfcn-diamond-c/libs/base.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libbase.so - shared leaf of the diamond DT_NEEDED graph.
+ *
+ *   libdiamond.so
+ *     +-- DT_NEEDED libleft.so   --+
+ *     +-- DT_NEEDED libright.so  --+-- DT_NEEDED libbase.so
+ *
+ * Both libleft.so and libright.so declare DT_NEEDED libbase.so. When the
+ * loader walks libdiamond.so's dependencies, it must NOT load libbase.so
+ * twice -- exactly one copy should appear in the registry. Otherwise the
+ * `unique_counter` global below would be visible at two distinct
+ * addresses to libleft.so and libright.so, and the assertion in
+ * dlfcn-diamond-c/main.c would fire.
+ */
+
+/* Process-lifetime counter. Bumped by every call to `base_bump()`. */
+static int unique_counter = 0;
+
+int base_bump(void)
+{
+    unique_counter += 1;
+    return unique_counter;
+}
+
+int base_get(void)
+{
+    return unique_counter;
+}

--- a/src/dlfcn-diamond-c/libs/diamond.c
+++ b/src/dlfcn-diamond-c/libs/diamond.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libdiamond.so - root of the diamond. Pulls in libleft.so and
+ * libright.so via DT_NEEDED. Both arms transitively depend on
+ * libbase.so, so a correct loader must consolidate the two
+ * "DT_NEEDED libbase.so" edges onto a single libbase.so instance.
+ */
+
+extern int left_bump(void);
+extern int right_bump(void);
+extern int right_get(void);
+
+int diamond_left(void)
+{
+    return left_bump();
+}
+
+int diamond_right(void)
+{
+    return right_bump();
+}
+
+int diamond_observe(void)
+{
+    return right_get();
+}

--- a/src/dlfcn-diamond-c/libs/left.c
+++ b/src/dlfcn-diamond-c/libs/left.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libleft.so - left arm of the diamond. Calls base_bump() so the test
+ * can observe whether libleft and libright share the same libbase.so
+ * instance (single counter) or each got their own (independent counters).
+ */
+
+extern int base_bump(void);
+
+int left_bump(void)
+{
+    return base_bump();
+}

--- a/src/dlfcn-diamond-c/libs/right.c
+++ b/src/dlfcn-diamond-c/libs/right.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * libright.so - right arm of the diamond. Symmetric to libleft.so.
+ */
+
+extern int base_bump(void);
+extern int base_get(void);
+
+int right_bump(void)
+{
+    return base_bump();
+}
+
+int right_get(void)
+{
+    return base_get();
+}

--- a/src/dlfcn-diamond-c/main.c
+++ b/src/dlfcn-diamond-c/main.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ *
+ * dlfcn-diamond-c: Exercises diamond DT_NEEDED graph resolution.
+ *
+ *   libdiamond.so
+ *     +-- DT_NEEDED libleft.so   --+
+ *     +-- DT_NEEDED libright.so  --+-- DT_NEEDED libbase.so
+ *
+ * A correct loader walks libdiamond.so's dependencies, opens libleft.so,
+ * recurses into its DT_NEEDED list and opens libbase.so, then resumes
+ * the outer loop for libright.so -- at which point libbase.so is already
+ * in the registry and must be bound, NOT re-opened. A broken loader
+ * either:
+ *   (a) re-opens libbase.so, ending up with two copies and two distinct
+ *       `unique_counter` instances, OR
+ *   (b) trips an internal `unreachable!()` / hangs because the same
+ *       file descriptor is now mapped to two registry entries.
+ *
+ * Both failure modes are caught by the assertions below.
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void pass(const char *name)
+{
+    printf("  PASS: %s\n", name);
+    fflush(stdout);
+    tests_passed++;
+}
+
+static void fail(const char *name, const char *reason)
+{
+    printf("  FAIL: %s (%s)\n", name, reason);
+    fflush(stdout);
+    tests_failed++;
+}
+
+/*
+ * Test 0 (control): dlopen libright.so directly. libright has a single
+ * DT_NEEDED edge to libbase.so, so this exercises the depth-2 chain
+ * without involving the diamond shape. If this hangs, the issue is
+ * not specific to diamond resolution.
+ */
+static void test_chain_dlopen(void)
+{
+    void *h = dlopen("lib/libright.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("dlopen(libright.so) [depth-2]", dlerror());
+        return;
+    }
+    int (*rb)(void) = (int (*)(void))dlsym(h, "right_bump");
+    if (!rb || rb() != 1) {
+        fail("dlopen(libright.so) [depth-2]", "right_bump returned wrong value");
+        dlclose(h);
+        return;
+    }
+    dlclose(h);
+    pass("dlopen(libright.so) [depth-2 chain]");
+}
+
+/*
+ * Test 1: dlopen(libdiamond.so) must succeed (not hang, not error).
+ * Successful return implies the loader walked the entire diamond
+ * graph without re-opening libbase.so or otherwise dead-locking.
+ */
+static void test_diamond_dlopen(void)
+{
+    void *h = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h == NULL) {
+        fail("dlopen(libdiamond.so)", dlerror());
+        return;
+    }
+
+    int (*dl) (void) = (int (*)(void))dlsym(h, "diamond_left");
+    int (*dr) (void) = (int (*)(void))dlsym(h, "diamond_right");
+    int (*ob) (void) = (int (*)(void))dlsym(h, "diamond_observe");
+    if (!dl || !dr || !ob) {
+        fail("dlopen(libdiamond.so)", "missing diamond_* symbols");
+        dlclose(h);
+        return;
+    }
+
+    /*
+     * Capture the baseline counter before the diamond arms run.  This
+     * keeps the test robust against any prior `test_chain_dlopen()`
+     * call leaving the counter at a non-zero value if Nanvix's
+     * `dlclose` ever stops fully unmapping the library (POSIX permits
+     * `dlclose` to defer the unmap).  We then assert deltas, not
+     * absolute values:
+     *
+     *   left_val   = base_get() + 1 after left's base_bump()
+     *   right_val  = base_get() + 2 after right's base_bump()
+     *   observed   = base_get() + 2
+     *
+     * If libbase.so were loaded twice, libleft and libright would each
+     * see their own private `unique_counter` starting at zero, so
+     * left_val == 1, right_val == 1 (not 2), observed == 1 (not 2).
+     */
+    int (*base_get_addr)(void) = (int (*)(void))dlsym(h, "base_get");
+    int baseline = base_get_addr ? base_get_addr() : 0;
+
+    int left_val = dl();
+    int right_val = dr();
+    int observed = ob();
+
+    if (left_val != baseline + 1) {
+        char reason[96];
+        snprintf(reason, sizeof(reason),
+                 "left_bump=%d, expected %d", left_val, baseline + 1);
+        fail("dlopen(libdiamond.so)", reason);
+        dlclose(h);
+        return;
+    }
+    if (right_val != baseline + 2 || observed != baseline + 2) {
+        /* This is the giveaway for a duplicate libbase.so: libleft and
+         * libright each see their own private `unique_counter` instead
+         * of sharing one. */
+        char reason[160];
+        snprintf(reason, sizeof(reason),
+                 "right_bump=%d (expected %d), observed=%d (expected %d) "
+                 "-- libbase.so was loaded twice",
+                 right_val, baseline + 2, observed, baseline + 2);
+        fail("dlopen(libdiamond.so)", reason);
+        dlclose(h);
+        return;
+    }
+
+    dlclose(h);
+    pass("dlopen(libdiamond.so)");
+}
+
+/*
+ * Test 2: Second dlopen returns the same handle (libdiamond.so is
+ * already in the registry).
+ */
+static void test_diamond_reopen(void)
+{
+    void *h1 = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h1 == NULL) {
+        fail("re-dlopen(libdiamond.so)", dlerror());
+        return;
+    }
+
+    void *h2 = dlopen("lib/libdiamond.so", RTLD_NOW);
+    if (h2 == NULL) {
+        fail("re-dlopen(libdiamond.so)", dlerror());
+        dlclose(h1);
+        return;
+    }
+
+    if (h1 != h2) {
+        fail("re-dlopen(libdiamond.so)", "second dlopen returned a different handle");
+        dlclose(h1);
+        dlclose(h2);
+        return;
+    }
+
+    dlclose(h1);
+    dlclose(h2);
+    pass("re-dlopen(libdiamond.so) returns same handle");
+}
+
+int main(int argc, const char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== dlfcn diamond DT_NEEDED tests ===\n");
+    fflush(stdout);
+
+    test_chain_dlopen();
+    test_diamond_dlopen();
+    test_diamond_reopen();
+
+    printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    fflush(stdout);
+
+    if (tests_failed == 0) {
+        const char *magic = "ok";
+        write(STDOUT_FILENO, magic, 3);
+    }
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Adds a new `src/dlfcn-diamond-c/` regression suite that exercises diamond `DT_NEEDED` graphs, the canonical multi-edge shape that production shared-library chains take. The suite is the canonical end-to-end test for the in-process Nanvix loader's handling of multi-arm dependency consolidation; once the companion loader PR `nanvix/nanvix#2478` lands, this suite is what pins the behaviour in place.

## Why this matters

A diamond `DT_NEEDED` graph looks like this:

```
libdiamond.so -> libleft.so  -> libbase.so
              -> libright.so -> libbase.so
```

The cardinal correctness signal is that `libbase.so` must be loaded **exactly once**: the loader walks libdiamond's dependencies, opens libleft, recurses into libleft's `DT_NEEDED` and opens libbase, then resumes the outer loop for libright -- at which point libbase is already in the registry and must be bound, not re-opened. A broken loader either (a) re-opens libbase, ending up with two copies and two distinct copies of every libbase global; or (b) trips an internal `unreachable!()` / hangs because the same fd is now mapped to two registry entries; or (c) panics in `dlclose` because libbase's Arc refcount exceeds the expected value when the dependent libs hold references to it.

All three failure modes are exercised by the assertions below. The companion loader PR `nanvix/nanvix#2478` addresses the deadlock (a/b above) and the over-strict `dlclose` assertion (c above). The existing `src/dlfcn-needed-c` suite stays a single-edge linear graph, so it never tripped any of these paths.

## Test matrix

3 cases, all in `main.c`. The suite uses the `printf "  PASS: ..." / "  FAIL: ..."` + counter convention shared by the sibling `src/dlfcn-init-runpath-c` suite. A non-zero count of failures causes the suite to exit non-zero.

| # | Case | Asserts |
|---|------|---------|
| 1 | `dlopen("lib/libright.so")` [depth-2 control] | depth-2 chain `libright -> libbase` works; passes on stock Nanvix; tripwire for the test rig itself |
| 2 | `dlopen("lib/libdiamond.so")` | diamond load succeeds; left-arm `base_bump()` increments the counter; right-arm `base_bump()` increments the same counter; `base_get()` observes the cumulative value (proves libbase is shared) |
| 3 | `dlopen("lib/libdiamond.so")` twice | both calls return the same handle (POSIX `dlopen` idempotence) |

The "libbase loaded twice" failure mode would be reported as `right_bump=N (expected M)`, where M is `baseline+2` and N is `baseline+1` (each arm sees its own private counter starting from its own baseline). The test reads `baseline = base_get()` before invoking the arms and asserts deltas, so it stays robust against an unrelated test having previously bumped the counter (or a future Nanvix `dlclose` policy that defers the unmap).

## Build-time fixture verification

The Makefile uses `readelf -d` to assert that each fixture `.so` carries the `DT_NEEDED` set the test assumes:

- `libleft.so` must `DT_NEEDED libbase.so`
- `libright.so` must `DT_NEEDED libbase.so`
- `libdiamond.so` must `DT_NEEDED libleft.so` and `DT_NEEDED libright.so`

This catches toolchain regressions where a build accidentally produces a flat-linked or under-linked fixture that no longer exercises the diamond shape.

## Linker flags

Main executable: `-pie -rdynamic -Wl,--no-dynamic-linker` (matches the sibling `dlfcn-*-c` suites). `--no-dynamic-linker` because Nanvix uses an in-process loader via syscalls, not a separate `ld.so`. Each `.so` with dependencies is built with `-Wl,--enable-new-dtags,-rpath,lib` so the linker emits `DT_RUNPATH lib` (not the deprecated `DT_RPATH`), matching the resolver pattern used by the existing `dlfcn-init-runpath-c` suite. `libbase.so` is a leaf and does not need the flag.

## Suite wiring

Hooks into `src/Makefile` (`SUITES`), the host top-level `Makefile` (`SUITES`), and `.nanvix/z.py` (`ALL_SUITES`, `STANDALONE_ONLY_SUITES`, and `SUITE_RAMFS_LIBS` -- the last bundles the 4 fixture `.so` files into the ramfs under `lib/` where `main.c` opens them).

## Stacking

Based on the `nanvix/posix-tests:feat/dlfcn-init-array-and-runpath` branch (PR #174), since both PRs share the suite-wiring infrastructure (`SUITE_RAMFS_LIBS`, the `STANDALONE_ONLY_SUITES` entry, etc.). Merge order: #174 first, then this PR.

## Validation

End-to-end run on a standalone Nanvix VM built from `nanvix/nanvix#2478`'s loader branch: all 3 cases pass; full posix-tests integration suite (16 testable suites) passes. Local `z lint` (pyright) and `z format --check` (black) report clean.
