### PR TITLE
[build] E: Link libnvx_crt0.a into test ELFs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,9 +51,10 @@ export LDFLAGS := -z noexecstack -T $(NANVIX_SYSROOT)/lib/user.ld
 # Libraries.
 export LIBPOSIX := $(NANVIX_SYSROOT)/lib/libposix.a
 export LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
-export LIBRARIES := -Wl,--start-group $(LIBPOSIX) $(LIBC) -Wl,--end-group
+export LIBNVX_CRT0 := $(NANVIX_SYSROOT)/lib/libnvx_crt0.a
+export LIBRARIES := -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export LIBCXX := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libstdc++.a
-export LIBRARIES_CXX := -Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-group
+export LIBRARIES_CXX := -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-group
 
 # Output directory for compiled binaries.
 export BINARIES_DIR ?= $(CURDIR)/../build


### PR DESCRIPTION
## Summary

[nanvix/nanvix#2453](https://github.com/nanvix/nanvix/pull/2453) (already upstream) moved the `_start` entry point out of `libposix.a` into a new `libnvx_crt0.a`. Add `libnvx_crt0.a` to both the `LIBRARIES` and `LIBRARIES_CXX` link wrappers in `src/Makefile` so every posix-tests test ELF gets `_start` at link time. Without this the linker silently picks newlib's weak default `_start` and the test hangs at startup with no diagnostic output.

## Dependencies

This PR assumes the following have already merged and the toolchain image has been republished:

- [nanvix/nanvix#2487](https://github.com/nanvix/nanvix/pull/2487) — `sys-ffi` crate split that removes the duplicate `__kcall_*` / `_do_exit_thread` / `_do_start_thread` strong symbols from `libnvx_crt0.a`.
- [nanvix/newlib#17](https://github.com/nanvix/newlib/pull/17) — declares newlib's `_do_start` as `.weak` so `libnvx_crt0`'s strong SSE-aligned override wins cleanly without `-Wl,--allow-multiple-definition`.
- [nanvix/toolchain-gcc#14](https://github.com/nanvix/toolchain-gcc/pull/14) — pins the new newlib commit and triggers a republish of `ghcr.io/nanvix/toolchain-gcc`.

If those have not landed, the link line will fail with `multiple definition of __kcall_*` errors against the unpatched toolchain image.

## What changes

A new `LIBNVX_CRT0` variable is exported alongside `LIBPOSIX` and `LIBC`, and added inside the existing `--start-group` ahead of `LIBPOSIX` in both `LIBRARIES` and `LIBRARIES_CXX` so every test ELF gets `_start` resolved from libnvx_crt0's strong symbol.
