### PR TITLE
[build] F: Drop -Wl,--allow-multiple-definition (no longer needed)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,11 +64,9 @@ export LIBNVX_CRT0 := $(wildcard $(NANVIX_SYSROOT)/lib/libnvx_crt0.a)
 # copies are byte-identical (same source, same release profile), so it
 # is safe to let the linker take whichever it sees first.  See the
 # `libnvx_crt0-duplicates-sys-symbols` upstream issue for the proper fix.
-export LIBRARIES := -Wl,--allow-multiple-definition \
-                    -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) -Wl,--end-group
+export LIBRARIES := -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) -Wl,--end-group
 export LIBCXX := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libstdc++.a
-export LIBRARIES_CXX := -Wl,--allow-multiple-definition \
-                        -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-group
+export LIBRARIES_CXX := -Wl,--start-group $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBCXX) -Wl,--end-group
 
 # Output directory for compiled binaries.
 export BINARIES_DIR ?= $(CURDIR)/../build


### PR DESCRIPTION
> [!IMPORTANT]
> **DO NOT MERGE** until ALL of the following have landed and propagated:
>
> 1. [nanvix/nanvix#2487](https://github.com/nanvix/nanvix/pull/2487) — `sys-ffi` crate split that removes 36 of 37 duplicate strong symbols.
> 2. [nanvix/newlib#17](https://github.com/nanvix/newlib/pull/17) — weakens `_do_start` in newlib's `crt0.S` so libnvx_crt0's strong override wins (the 37th duplicate).
> 3. [nanvix/toolchain-gcc#14](https://github.com/nanvix/toolchain-gcc/pull/14) — pins the new newlib commit and republishes the toolchain image (DRAFT until #17 merges).
> 4. The Docker image at `ghcr.io/nanvix/toolchain-gcc` has actually been republished from #14 with the new newlib bundled in.
> 5. The parent **E:** PR that this PR is stacked on top of (the one that added the `libnvx_crt0.a` wildcard link entry with the safety flag).
>
> If merged early, the link step for the test ELF will fail with `multiple definition of __kcall_*` errors against the unpatched toolchain image.

## Summary

Drops `-Wl,--allow-multiple-definition` from the test ELF link line. The flag was added by the parent **E:** PR as a temporary safety guard while 37 duplicate strong symbols were still present in both `libnvx_crt0.a` and `libposix.a`. Once those are resolved structurally, the flag is no longer needed and the SSE-aligned `_do_start` from `libnvx_crt0.a` finally wins at the entry point.

## Why the flag was needed

`libnvx_crt0.a` and `libposix.a` both contained byte-identical duplicate strong definitions of:

- 34 sys-crate `__kcall_*` FFI wrappers
- `_do_exit_thread`
- `_do_start_thread`
- `_do_start` (which also collides with newlib's prebuilt `crt0.o`)

`-Wl,--allow-multiple-definition` told `ld` to silently take whichever copy it saw first. Since the copies were byte-identical (same Rust source, same `--release` profile, same compiler), the outcome was semantically equivalent to deduplication -- but the flag also hides legitimate symbol collisions, which is why it was always intended to be temporary.

## How the duplicates have been resolved

- **36 of 37** -- [nanvix/nanvix#2487](https://github.com/nanvix/nanvix/pull/2487) introduces a `sys-ffi` crate that owns all `#[no_mangle]` re-exports of `sys::kcall::*`. Only `libposix.a` links `sys-ffi`, so `libnvx_crt0.a` no longer duplicates the `__kcall_*` / `_do_exit_thread` / `_do_start_thread` symbols.
- **The 37th** (`_do_start` colliding between `libnvx_crt0.a` and newlib's prebuilt `crt0.o`) -- [nanvix/newlib#17](https://github.com/nanvix/newlib/pull/17) declares newlib's stub `.weak` so `libnvx_crt0`'s strong SSE-aligned `_do_start` wins cleanly without the flag.
- **Toolchain image republish** -- [nanvix/toolchain-gcc#14](https://github.com/nanvix/toolchain-gcc/pull/14) bumps the pinned newlib commit and triggers a republish of `ghcr.io/nanvix/toolchain-gcc` so all consumers get the new newlib.

Until ALL three changes land AND the toolchain image is republished, this PR's link step will fail. That is why this is a deliberately-separate follow-up PR rather than being squashed into the parent E: PR -- it gives reviewers the option to merge the E: compat fix immediately (preserving backward compatibility with both pre-cutover and post-cutover sysroots, with the safety flag) and circle back to drop the flag in a single small PR once the toolchain catches up.

## Side benefit: SSE-aligned `_do_start` at the entry point

With the flag in place, `ld` silently takes newlib's 9-byte unaligned `_do_start` (crt files come first in the gcc spec). Dropping the flag lets `libnvx_crt0`'s 18-byte SSE-aligned variant -- which aligns `%esp` to a 16-byte boundary before the `CALL` instruction, as required by the i386 SysV ABI for SSE-using callees (`movaps` / `movdqa`) -- finally win. This fixes a latent SSE-alignment bug present in shipping binaries today.

## Validation

Built end-to-end against a locally-rebuilt toolchain image carrying the nanvix/newlib#17 change. Test ELF links cleanly without `--allow-multiple-definition`. Disassembling the resulting binary confirms `_do_start` at the entry point is the SSE-aligned variant:

```
<_do_start>:
    and    $0xfffffff0, %esp      ; 16-byte align (was missing)
    mov    %esp, %ebp
    sub    $0x8, %esp              ; alignment padding (was missing)
    push   %ecx
    push   %edx
    call   _start
```
