### PR TITLE
[ci] E: Update nanvix workflow refs to v2.6.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.5.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.6.0
     with:
       docker-image: >-
         ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.6.0`](https://github.com/nanvix/workflows/releases/tag/v2.6.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.