### PR TITLE
[ci] E: Update nanvix workflow refs to v3.0.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.6.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v3.0.0
     with:
       platforms: '["microvm"]'
       process-modes: '["single-process","standalone"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v3.0.0`](https://github.com/nanvix/workflows/releases/tag/v3.0.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.